### PR TITLE
Robust peer extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,6 +725,7 @@ dependencies = [
  "tokio-stream",
  "tower",
  "tower-service",
+ "winnow",
  "wyrand",
 ]
 
@@ -1570,6 +1571,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ bytes = "1.10.1"
 futures-lite = "2.6.0"
 scc = "2.3.3"
 parking_lot.workspace = true
+winnow = { version = "0.7.6" }
 
 [profile.release]
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ bytes = "1.10.1"
 futures-lite = "2.6.0"
 scc = "2.3.3"
 parking_lot.workspace = true
-winnow = { version = "0.7.6" }
+winnow = { version = "0.7.6", features = ["simd"] }
 
 [profile.release]
 codegen-units = 1

--- a/src/fv_parser.rs
+++ b/src/fv_parser.rs
@@ -8,8 +8,7 @@ use winnow::{
 };
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-/// Remote identifier. This can be an IP:port pair, a bare IP, an underscore-prefixed
-/// "obfuscated string", or unknown.
+/// Remote identifier. This can be an IP:port pair or a bare IP.
 pub enum Identifier {
     SocketAddr(SocketAddr),
     IpAddr(IpAddr),

--- a/src/fv_parser.rs
+++ b/src/fv_parser.rs
@@ -22,12 +22,10 @@ fn match_for<'s>(prefix: &mut &'s str) -> ModalResult<&'s str> {
 /// the port info.
 fn extract_ipv6(identifier: &mut &str) -> ModalResult<IpAddr> {
     literal("\"[").parse_next(identifier)?;
-    let ip = take_until(0.., ']')
-        .parse_to::<IpAddr>()
-        .parse_next(identifier)?;
-    literal("]").parse_next(identifier)?;
-
-    Ok(ip)
+    take_until(0.., ']')
+        .parse_to()
+        .map(IpAddr::V6)
+        .parse_next(identifier)
 }
 
 /// Extracts the IPv4 address from the identifier string. Expects the format
@@ -35,7 +33,10 @@ fn extract_ipv6(identifier: &mut &str) -> ModalResult<IpAddr> {
 /// addresses. The port component `:8080` may or may not be present in the identifier.
 /// For the purposes of `nailpit`, we discard the port info.
 fn extract_ipv4(identifier: &mut &str) -> ModalResult<IpAddr> {
-    take_till(0.., ':').parse_to().parse_next(identifier)
+    take_till(0.., ':')
+        .parse_to()
+        .map(IpAddr::V4)
+        .parse_next(identifier)
 }
 
 /// Extracts the identifier from the Forwarded for value. Attempts to parse the identifier part
@@ -64,7 +65,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn extracts_for() -> color_eyre::Result<()> {
+    fn extracts_for_header_value() -> color_eyre::Result<()> {
         assert_eq!(
             extract_for
                 .parse("for=1.2.3.4")

--- a/src/fv_parser.rs
+++ b/src/fv_parser.rs
@@ -1,0 +1,110 @@
+use std::net::{IpAddr, Ipv6Addr, SocketAddr, SocketAddrV4};
+
+use winnow::{
+    ModalResult, Parser,
+    ascii::{Caseless, digit1},
+    combinator::{alt, opt},
+    token::{literal, rest, take_till, take_until},
+};
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+/// Remote identifier. This can be an IP:port pair, a bare IP, an underscore-prefixed
+/// "obfuscated string", or unknown.
+pub enum Identifier {
+    SocketAddr(SocketAddr),
+    IpAddr(IpAddr),
+}
+
+fn match_for<'s>(s: &mut &'s str) -> ModalResult<&'s str> {
+    Caseless("for=").parse_next(s)
+}
+
+fn match_port(s: &mut &str) -> ModalResult<Option<u16>> {
+    Ok(opt((":", digit1))
+        .parse_next(s)?
+        .and_then(|(_, b)| b.parse::<u16>().ok()))
+}
+
+fn extract_ipv6(s: &mut &str) -> ModalResult<Identifier> {
+    literal("\"[").parse_next(s)?;
+    let ip = take_until(0.., ']').parse_to::<Ipv6Addr>().parse_next(s)?;
+    literal("]").parse_next(s)?;
+    let port = match_port.parse_next(s)?;
+
+    match (ip, port) {
+        (ip, None) => Ok(Identifier::IpAddr(IpAddr::V6(ip))),
+        (ip, Some(port)) => Ok(Identifier::SocketAddr(SocketAddr::new(
+            IpAddr::V6(ip),
+            port,
+        ))),
+    }
+}
+
+fn extract_ipv4(s: &mut &str) -> ModalResult<Identifier> {
+    let ip = take_till(0.., ':').parse_to().parse_next(s)?;
+    let port = match_port.parse_next(s)?;
+
+    match (ip, port) {
+        (ip, None) => Ok(Identifier::IpAddr(IpAddr::V4(ip))),
+        (ip, Some(port)) => Ok(Identifier::SocketAddr(SocketAddr::V4(SocketAddrV4::new(
+            ip, port,
+        )))),
+    }
+}
+
+fn extract_identifier(s: &mut &str) -> ModalResult<Identifier> {
+    alt((extract_ipv6, extract_ipv4)).parse_next(s)
+}
+
+pub fn extract_for(s: &mut &str) -> ModalResult<Identifier> {
+    match_for.parse_next(s)?;
+
+    let id = extract_identifier.parse_next(s)?;
+
+    rest.parse_next(s)?;
+
+    Ok(id)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    use super::*;
+
+    #[test]
+    fn extracts_for() -> color_eyre::Result<()> {
+        assert_eq!(
+            extract_for
+                .parse("for=1.2.3.4")
+                .map_err(|a| color_eyre::eyre::eyre!("Identifier parsing error:\n{a}"))?,
+            Identifier::IpAddr(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)))
+        );
+
+        assert_eq!(
+            extract_for
+                .parse("fOr=1.2.3.4:1234")
+                .map_err(|a| color_eyre::eyre::eyre!("Identifier parsing error:\n{a}"))?,
+            Identifier::SocketAddr(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), 1234))
+        );
+
+        assert_eq!(
+            extract_for
+                .parse("FoR=\"[::1]:1234\"")
+                .map_err(|a| color_eyre::eyre::eyre!("Identifier parsing error:\n{a}"))?,
+            Identifier::SocketAddr(SocketAddr::new(
+                IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
+                1234
+            ))
+        );
+
+        assert_eq!(
+            extract_for
+                .parse("FOR=\"[::1]\"")
+                .map_err(|a| color_eyre::eyre::eyre!("Identifier parsing error:\n{a}"))?,
+            Identifier::IpAddr(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)))
+        );
+
+        Ok(())
+    }
+}

--- a/src/fv_parser.rs
+++ b/src/fv_parser.rs
@@ -1,66 +1,58 @@
-use std::net::{IpAddr, Ipv6Addr, SocketAddr, SocketAddrV4};
+use std::net::IpAddr;
 
 use winnow::{
     ModalResult, Parser,
-    ascii::{Caseless, digit1},
-    combinator::{alt, opt},
-    token::{literal, rest, take_till, take_until},
+    ascii::Caseless,
+    combinator::alt,
+    stream::Stream,
+    token::{literal, take_till, take_until},
 };
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-/// Remote identifier. This can be an IP:port pair or a bare IP.
-pub enum Identifier {
-    SocketAddr(SocketAddr),
-    IpAddr(IpAddr),
+/// Check if a header value string begins with `for=`, in order to
+/// determine whether it is a valid value for a Forwarded header, and
+/// is a part that we are interested in.
+fn match_for<'s>(prefix: &mut &'s str) -> ModalResult<&'s str> {
+    Caseless("for=").parse_next(prefix)
 }
 
-fn match_for<'s>(s: &mut &'s str) -> ModalResult<&'s str> {
-    Caseless("for=").parse_next(s)
+/// Extracts the IPv6 address from the identifier string. Expects the format
+/// `"[::1]:8080"`. IPv6 addresses in the Forwarded header are always wrapped in `"`,
+/// with the address component wrapped in square brackets. The port component `:8080`
+/// may or may not be present in the identifier. For the purposes of `nailpit`, we discard
+/// the port info.
+fn extract_ipv6(identifier: &mut &str) -> ModalResult<IpAddr> {
+    literal("\"[").parse_next(identifier)?;
+    let ip = take_until(0.., ']')
+        .parse_to::<IpAddr>()
+        .parse_next(identifier)?;
+    literal("]").parse_next(identifier)?;
+
+    Ok(ip)
 }
 
-fn match_port(s: &mut &str) -> ModalResult<Option<u16>> {
-    Ok(opt((":", digit1))
-        .parse_next(s)?
-        .and_then(|(_, b)| b.parse::<u16>().ok()))
+/// Extracts the IPv4 address from the identifier string. Expects the format
+/// `192.168.0.1:8080`. IPv4 addresses are not wrapped with `"` in contrast to IPv6
+/// addresses. The port component `:8080` may or may not be present in the identifier.
+/// For the purposes of `nailpit`, we discard the port info.
+fn extract_ipv4(identifier: &mut &str) -> ModalResult<IpAddr> {
+    take_till(0.., ':').parse_to().parse_next(identifier)
 }
 
-fn extract_ipv6(s: &mut &str) -> ModalResult<Identifier> {
-    literal("\"[").parse_next(s)?;
-    let ip = take_until(0.., ']').parse_to::<Ipv6Addr>().parse_next(s)?;
-    literal("]").parse_next(s)?;
-    let port = match_port.parse_next(s)?;
-
-    match (ip, port) {
-        (ip, None) => Ok(Identifier::IpAddr(IpAddr::V6(ip))),
-        (ip, Some(port)) => Ok(Identifier::SocketAddr(SocketAddr::new(
-            IpAddr::V6(ip),
-            port,
-        ))),
-    }
+/// Extracts the identifier from the Forwarded for value. Attempts to parse the identifier part
+/// as either an IPv6 address or IPv4 address. The Forwarded for format supports more identifier
+/// types, but we discard those as they are useless to us.
+fn extract_identifier(identifier: &mut &str) -> ModalResult<IpAddr> {
+    alt((extract_ipv6, extract_ipv4)).parse_next(identifier)
 }
 
-fn extract_ipv4(s: &mut &str) -> ModalResult<Identifier> {
-    let ip = take_till(0.., ':').parse_to().parse_next(s)?;
-    let port = match_port.parse_next(s)?;
+/// Extracts the identifier from the Forwarded for value. First it checks for the correct
+/// prefix `for=`, then attempts to extract the identifier.
+pub fn extract_for(header_part: &mut &str) -> ModalResult<IpAddr> {
+    match_for.parse_next(header_part)?;
 
-    match (ip, port) {
-        (ip, None) => Ok(Identifier::IpAddr(IpAddr::V4(ip))),
-        (ip, Some(port)) => Ok(Identifier::SocketAddr(SocketAddr::V4(SocketAddrV4::new(
-            ip, port,
-        )))),
-    }
-}
+    let id = extract_identifier.parse_next(header_part)?;
 
-fn extract_identifier(s: &mut &str) -> ModalResult<Identifier> {
-    alt((extract_ipv6, extract_ipv4)).parse_next(s)
-}
-
-pub fn extract_for(s: &mut &str) -> ModalResult<Identifier> {
-    match_for.parse_next(s)?;
-
-    let id = extract_identifier.parse_next(s)?;
-
-    rest.parse_next(s)?;
+    header_part.finish();
 
     Ok(id)
 }
@@ -77,31 +69,28 @@ mod tests {
             extract_for
                 .parse("for=1.2.3.4")
                 .map_err(|a| color_eyre::eyre::eyre!("Identifier parsing error:\n{a}"))?,
-            Identifier::IpAddr(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)))
+            IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))
         );
 
         assert_eq!(
             extract_for
                 .parse("fOr=1.2.3.4:1234")
                 .map_err(|a| color_eyre::eyre::eyre!("Identifier parsing error:\n{a}"))?,
-            Identifier::SocketAddr(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), 1234))
+            IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))
         );
 
         assert_eq!(
             extract_for
                 .parse("FoR=\"[::1]:1234\"")
                 .map_err(|a| color_eyre::eyre::eyre!("Identifier parsing error:\n{a}"))?,
-            Identifier::SocketAddr(SocketAddr::new(
-                IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
-                1234
-            ))
+            IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))
         );
 
         assert_eq!(
             extract_for
                 .parse("FOR=\"[::1]\"")
                 .map_err(|a| color_eyre::eyre::eyre!("Identifier parsing error:\n{a}"))?,
-            Identifier::IpAddr(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)))
+            IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))
         );
 
         Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ mod markov;
 mod rng;
 mod shutdown;
 mod state;
-mod peer_limiter;
+mod peer;
 mod fv_parser;
 
 use std::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,8 @@ mod markov;
 mod rng;
 mod shutdown;
 mod state;
+mod peer_limiter;
+mod fv_parser;
 
 use std::{
     net::SocketAddr,

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -35,6 +35,7 @@ impl ProxiedPeer {
     }
 
     /// Returns the extracted [`IpAddr`].
+    #[inline]
     pub fn ip(&self) -> IpAddr {
         self.0
     }

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -1,6 +1,12 @@
-use std::net::{IpAddr, SocketAddr};
+use std::{
+    convert::Infallible,
+    net::{IpAddr, SocketAddr},
+};
 
-use axum::extract::Request;
+use axum::{
+    extract::{ConnectInfo, FromRequestParts},
+    http::request::Parts,
+};
 use hyper::{HeaderMap, header::FORWARDED};
 use winnow::Parser;
 
@@ -10,21 +16,37 @@ const X_REAL_IP: &str = "x-real-ip";
 const X_FORWARDED_FOR: &str = "x-forwarded-for";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct PeerExtractor;
+#[repr(align(8))]
+pub struct ProxiedPeer(IpAddr);
 
-impl PeerExtractor {
-    pub fn extract<T>(&self, req: &Request<T>) -> Option<IpAddr> {
-        let headers = req.headers();
+impl ProxiedPeer {
+    pub fn extract(headers: &HeaderMap, connection: &ConnectInfo<SocketAddr>) -> Self {
+        Self(
+            maybe_x_forwarded_for(headers)
+                .or_else(|| maybe_x_real_ip(headers))
+                .or_else(|| maybe_forwarded(headers))
+                .unwrap_or_else(|| connection.ip()),
+        )
+    }
 
-        maybe_x_forwarded_for(headers)
-            .or_else(|| maybe_x_real_ip(headers))
-            .or_else(|| maybe_forwarded(headers))
-            .or_else(|| maybe_connect_info(req))
+    pub fn ip(&self) -> IpAddr {
+        self.0
+    }
+}
+
+impl<S: Send + Sync> FromRequestParts<S> for ProxiedPeer {
+    type Rejection = Infallible;
+
+    async fn from_request_parts(req: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        Ok(Self::extract(
+            &req.headers,
+            req.extensions.get::<ConnectInfo<SocketAddr>>().unwrap(),
+        ))
     }
 }
 
 /// Tries to parse the `x-forwarded-for` header
-fn maybe_x_forwarded_for(headers: &HeaderMap) -> Option<IpAddr> {
+pub fn maybe_x_forwarded_for(headers: &HeaderMap) -> Option<IpAddr> {
     headers
         .get(X_FORWARDED_FOR)
         .and_then(|hv| hv.to_str().ok())
@@ -32,7 +54,7 @@ fn maybe_x_forwarded_for(headers: &HeaderMap) -> Option<IpAddr> {
 }
 
 /// Tries to parse the `x-real-ip` header
-fn maybe_x_real_ip(headers: &HeaderMap) -> Option<IpAddr> {
+pub fn maybe_x_real_ip(headers: &HeaderMap) -> Option<IpAddr> {
     headers
         .get(X_REAL_IP)
         .and_then(|hv| hv.to_str().ok())
@@ -40,7 +62,7 @@ fn maybe_x_real_ip(headers: &HeaderMap) -> Option<IpAddr> {
 }
 
 /// Tries to parse `forwarded` headers
-fn maybe_forwarded(headers: &HeaderMap) -> Option<IpAddr> {
+pub fn maybe_forwarded(headers: &HeaderMap) -> Option<IpAddr> {
     headers.get_all(FORWARDED).iter().find_map(|hv| {
         hv.to_str()
             .ok()
@@ -58,11 +80,4 @@ fn maybe_forwarded(headers: &HeaderMap) -> Option<IpAddr> {
                 Identifier::IpAddr(ip_addr) => ip_addr,
             })
     })
-}
-
-/// Looks in `ConnectInfo` extension
-fn maybe_connect_info<T>(req: &Request<T>) -> Option<IpAddr> {
-    req.extensions()
-        .get::<axum::extract::ConnectInfo<SocketAddr>>()
-        .map(|addr| addr.ip())
 }

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -1,83 +1,88 @@
-use std::{
-    convert::Infallible,
-    net::{IpAddr, SocketAddr},
-};
+use std::net::{IpAddr, SocketAddr};
 
 use axum::{
     extract::{ConnectInfo, FromRequestParts},
     http::request::Parts,
 };
-use hyper::{HeaderMap, header::FORWARDED};
+use hyper::{HeaderMap, StatusCode, header::FORWARDED};
 use winnow::Parser;
 
-use crate::fv_parser::{Identifier, extract_for};
+use crate::fv_parser::extract_for;
 
 const X_REAL_IP: &str = "x-real-ip";
 const X_FORWARDED_FOR: &str = "x-forwarded-for";
 
+/// Extractor for obtaining an IP address from the request. Attempts to pull the IP from
+/// various headers expected from a reverse proxied connection, else falls back to [`ConnectInfo`]
+/// to get at least something if `nailpit` is not behind a proxy. If it can't get anything, then
+/// something is seriously wrong.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(align(8))]
 pub struct ProxiedPeer(IpAddr);
 
 impl ProxiedPeer {
-    pub fn extract(headers: &HeaderMap, connection: &ConnectInfo<SocketAddr>) -> Self {
-        Self(
-            maybe_x_forwarded_for(headers)
-                .or_else(|| maybe_x_real_ip(headers))
-                .or_else(|| maybe_forwarded(headers))
-                .unwrap_or_else(|| connection.ip()),
-        )
+    /// Extracts the IP address from either the request headers, or from the [`ConnectInfo`] extension
+    /// if it can't. Returns `None` if it finds nothing.
+    pub fn extract(
+        headers: &HeaderMap,
+        connection: Option<&ConnectInfo<SocketAddr>>,
+    ) -> Option<Self> {
+        maybe_x_forwarded_for(headers)
+            .or_else(|| maybe_x_real_ip(headers))
+            .or_else(|| maybe_forwarded(headers))
+            .or_else(|| connection.map(|connect_info| connect_info.ip()))
+            .map(Self)
     }
 
+    /// Returns the extracted [`IpAddr`].
     pub fn ip(&self) -> IpAddr {
         self.0
     }
 }
 
 impl<S: Send + Sync> FromRequestParts<S> for ProxiedPeer {
-    type Rejection = Infallible;
+    type Rejection = (StatusCode, &'static str);
 
     async fn from_request_parts(req: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
-        Ok(Self::extract(
+        Self::extract(
             &req.headers,
-            req.extensions.get::<ConnectInfo<SocketAddr>>().unwrap(),
-        ))
+            req.extensions.get::<ConnectInfo<SocketAddr>>(),
+        )
+        .ok_or((StatusCode::FORBIDDEN, "What are you hiding?"))
     }
 }
 
 /// Tries to parse the `x-forwarded-for` header
-pub fn maybe_x_forwarded_for(headers: &HeaderMap) -> Option<IpAddr> {
+fn maybe_x_forwarded_for(headers: &HeaderMap) -> Option<IpAddr> {
     headers
         .get(X_FORWARDED_FOR)
-        .and_then(|hv| hv.to_str().ok())
-        .and_then(|s| s.split(',').find_map(|s| s.trim().parse::<IpAddr>().ok()))
+        .and_then(|header_value| header_value.to_str().ok())
+        .and_then(|header| {
+            header
+                .split(',')
+                .map(str::trim)
+                .filter(|&header_parts| !header_parts.is_empty())
+                .find_map(|part| part.parse().ok())
+        })
 }
 
 /// Tries to parse the `x-real-ip` header
-pub fn maybe_x_real_ip(headers: &HeaderMap) -> Option<IpAddr> {
+fn maybe_x_real_ip(headers: &HeaderMap) -> Option<IpAddr> {
     headers
         .get(X_REAL_IP)
-        .and_then(|hv| hv.to_str().ok())
-        .and_then(|s| s.parse::<IpAddr>().ok())
+        .and_then(|header_value| header_value.to_str().ok())
+        .and_then(|header| header.trim().parse().ok())
 }
 
 /// Tries to parse `forwarded` headers
-pub fn maybe_forwarded(headers: &HeaderMap) -> Option<IpAddr> {
-    headers.get_all(FORWARDED).iter().find_map(|hv| {
-        hv.to_str()
-            .ok()
-            .and_then(|s| {
-                for sl in s.trim().split([',', ';']).filter(|&a| !a.is_empty()) {
-                    if let Ok(ip) = extract_for.parse(sl) {
-                        return Some(ip);
-                    }
-                }
-
-                None
-            })
-            .map(|f| match f {
-                Identifier::SocketAddr(socket_addr) => socket_addr.ip(),
-                Identifier::IpAddr(ip_addr) => ip_addr,
-            })
+fn maybe_forwarded(headers: &HeaderMap) -> Option<IpAddr> {
+    headers.get_all(FORWARDED).iter().find_map(|header_value| {
+        header_value.to_str().ok().and_then(|header| {
+            header
+                .split(&[',', ';'])
+                .map(str::trim)
+                .filter(|&header_parts| !header_parts.is_empty())
+                .find_map(|header_parts| extract_for.parse(header_parts).ok())
+        })
     })
 }

--- a/src/peer_limiter.rs
+++ b/src/peer_limiter.rs
@@ -1,0 +1,68 @@
+use std::net::{IpAddr, SocketAddr};
+
+use axum::extract::Request;
+use hyper::{HeaderMap, header::FORWARDED};
+use winnow::Parser;
+
+use crate::fv_parser::{Identifier, extract_for};
+
+const X_REAL_IP: &str = "x-real-ip";
+const X_FORWARDED_FOR: &str = "x-forwarded-for";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PeerExtractor;
+
+impl PeerExtractor {
+    pub fn extract<T>(&self, req: &Request<T>) -> Option<IpAddr> {
+        let headers = req.headers();
+
+        maybe_x_forwarded_for(headers)
+            .or_else(|| maybe_x_real_ip(headers))
+            .or_else(|| maybe_forwarded(headers))
+            .or_else(|| maybe_connect_info(req))
+    }
+}
+
+/// Tries to parse the `x-forwarded-for` header
+fn maybe_x_forwarded_for(headers: &HeaderMap) -> Option<IpAddr> {
+    headers
+        .get(X_FORWARDED_FOR)
+        .and_then(|hv| hv.to_str().ok())
+        .and_then(|s| s.split(',').find_map(|s| s.trim().parse::<IpAddr>().ok()))
+}
+
+/// Tries to parse the `x-real-ip` header
+fn maybe_x_real_ip(headers: &HeaderMap) -> Option<IpAddr> {
+    headers
+        .get(X_REAL_IP)
+        .and_then(|hv| hv.to_str().ok())
+        .and_then(|s| s.parse::<IpAddr>().ok())
+}
+
+/// Tries to parse `forwarded` headers
+fn maybe_forwarded(headers: &HeaderMap) -> Option<IpAddr> {
+    headers.get_all(FORWARDED).iter().find_map(|hv| {
+        hv.to_str()
+            .ok()
+            .and_then(|s| {
+                for sl in s.trim().split([',', ';']).filter(|&a| !a.is_empty()) {
+                    if let Ok(ip) = extract_for.parse(sl) {
+                        return Some(ip);
+                    }
+                }
+
+                None
+            })
+            .map(|f| match f {
+                Identifier::SocketAddr(socket_addr) => socket_addr.ip(),
+                Identifier::IpAddr(ip_addr) => ip_addr,
+            })
+    })
+}
+
+/// Looks in `ConnectInfo` extension
+fn maybe_connect_info<T>(req: &Request<T>) -> Option<IpAddr> {
+    req.extensions()
+        .get::<axum::extract::ConnectInfo<SocketAddr>>()
+        .map(|addr| addr.ip())
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,18 +1,20 @@
 use std::{
-    net::{IpAddr, SocketAddr},
+    net::IpAddr,
     ops::{Deref, DerefMut},
     sync::Arc,
     time::Instant,
 };
 
 use axum::{
-    extract::{ConnectInfo, FromRef, FromRequestParts, Request},
+    extract::{FromRef, FromRequestParts, Request},
     middleware::Next,
     response::Response,
 };
 use hyper::StatusCode;
 use scc::HashMap;
 use wyrand::RandomWyHashState;
+
+use crate::peer::ProxiedPeer;
 
 #[derive(Debug, Clone)]
 pub struct SourceState {
@@ -94,12 +96,14 @@ where
 #[fastrace::trace]
 pub async fn track_incoming_sources(
     sources: SourceMap,
-    source: ConnectInfo<SocketAddr>,
+    proxied: ProxiedPeer,
     request: Request,
     next: Next,
 ) -> Result<Response, StatusCode> {
+    let ip = proxied.ip();
+
     let seen = sources
-        .entry_async(source.ip())
+        .entry_async(ip)
         .await
         .and_modify(|source| {
             source.visited += 1;
@@ -110,7 +114,7 @@ pub async fn track_incoming_sources(
             last_seen: Instant::now(),
         });
 
-    log::info!("Saw: {} at {:?}", source.ip(), seen.last_seen);
+    log::info!("Saw: {} at {:?}", ip, seen.last_seen);
 
     Ok(next.run(request).await)
 }


### PR DESCRIPTION
Wrote my own Forwarded header parser for just pulling out the ip address I am interested in. Hooked the parsing to check for three different header types before defaulting to connect info to an extractor, so that is then tracked onto a hashmap of recent connected peers.

Closes #3 