### PR TITLE
Initial config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /input
 .cargo/config.toml
+pit.toml

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /target
 /input
 .cargo/config.toml
-pit.toml
+/configuration/pit.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "config"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595aae20e65c3be792d05818e8c63025294ac3cb7e200f11459063a352a6ef80"
+dependencies = [
+ "pathdiff",
+ "serde",
+ "toml",
+ "winnow",
+]
+
+[[package]]
 name = "cordyceps"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,10 +660,11 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
+ "getrandom",
  "libc",
 ]
 
@@ -791,7 +804,6 @@ dependencies = [
  "log",
  "rand",
  "rand_distr",
- "serde",
  "unicode-segmentation",
  "wyrand",
 ]
@@ -804,6 +816,7 @@ dependencies = [
  "axum-core",
  "bytes",
  "color-eyre",
+ "config",
  "fastrace",
  "fastrace-axum",
  "futures-concurrency",
@@ -818,6 +831,8 @@ dependencies = [
  "rand",
  "rand_core",
  "scc",
+ "serde",
+ "serde-aux",
  "tokio",
  "tokio-stream",
  "tower",
@@ -863,6 +878,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -902,6 +926,12 @@ dependencies = [
  "smallvec",
  "windows-targets",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -1025,7 +1055,6 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha",
  "rand_core",
- "serde",
  "zerocopy",
 ]
 
@@ -1046,7 +1075,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom",
- "serde",
 ]
 
 [[package]]
@@ -1131,6 +1159,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "scc"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1167,6 +1201,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-aux"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5290c39c5f6992b9dddbda28541d965dba46468294e6018a408fa297e6c602de"
+dependencies = [
+ "serde",
+ "serde-value",
+ "serde_json",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1175,6 +1230,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1316,6 +1392,40 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,9 @@ tower-http = { version = "0.6.2", features = [
     "compression-zstd",
     "normalize-path",
 ] }
+serde.workspace = true
+serde-aux = { version = "4.5.0", default-features = false }
+config = { version = "0.15.11", default-features = false, features = ["toml"] }
 
 [profile.release]
 codegen-units = 1

--- a/configuration/pit.default.toml
+++ b/configuration/pit.default.toml
@@ -1,0 +1,5 @@
+[generator]
+min_paragraph_size = 128
+max_paragraph_size = 256
+payload_size = 100
+timeout = 60

--- a/nailkov/Cargo.toml
+++ b/nailkov/Cargo.toml
@@ -8,7 +8,6 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
-serde = { workspace = true, optional = true }
 rand.workspace = true
 rand_distr.workspace = true
 wyrand.workspace = true
@@ -17,6 +16,3 @@ itertools.workspace = true
 unicode-segmentation.workspace = true
 log.workspace = true
 indexmap.workspace = true
-
-[features]
-serde = ["dep:serde", "rand/serde"]

--- a/pit.example.toml
+++ b/pit.example.toml
@@ -1,3 +1,0 @@
-[generator]
-min_size = 128
-max_size = 256

--- a/pit.example.toml
+++ b/pit.example.toml
@@ -1,0 +1,3 @@
+[generator]
+min_size = 128
+max_size = 256

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,43 @@
+use color_eyre::Result;
+use serde_aux::field_attributes::{
+    deserialize_number_from_string, deserialize_option_number_from_string,
+};
+
+#[derive(Debug, Default, serde::Deserialize)]
+pub struct NailConfig {
+    pub generator: GeneratorConfig,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct GeneratorConfig {
+    #[serde(deserialize_with = "deserialize_number_from_string")]
+    pub min_size: usize,
+    #[serde(deserialize_with = "deserialize_option_number_from_string")]
+    pub max_size: Option<usize>,
+}
+
+impl Default for GeneratorConfig {
+    fn default() -> Self {
+        Self {
+            min_size: 128,
+            max_size: None,
+        }
+    }
+}
+
+pub fn get_configuration() -> Result<NailConfig> {
+    let config_dir = std::env::current_dir()?;
+
+    let config = config::Config::builder()
+        .add_source(
+            config::File::from(config_dir.join("pit.toml")).format(config::FileFormat::Toml),
+        )
+        .add_source(
+            config::Environment::with_prefix("PIT")
+                .prefix_separator("__")
+                .separator("_"),
+        )
+        .build()?;
+
+    Ok(config.try_deserialize().unwrap_or_default())
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,33 +11,43 @@ pub struct NailConfig {
 #[derive(Debug, serde::Deserialize)]
 pub struct GeneratorConfig {
     #[serde(deserialize_with = "deserialize_number_from_string")]
-    pub min_size: usize,
+    pub min_paragraph_size: usize,
     #[serde(deserialize_with = "deserialize_option_number_from_string")]
-    pub max_size: Option<usize>,
+    pub max_paragraph_size: Option<usize>,
+    #[serde(deserialize_with = "deserialize_number_from_string")]
+    pub payload_size: usize,
+    #[serde(deserialize_with = "deserialize_number_from_string")]
+    pub timeout: u64,
 }
 
 impl Default for GeneratorConfig {
     fn default() -> Self {
         Self {
-            min_size: 128,
-            max_size: None,
+            min_paragraph_size: 128,
+            max_paragraph_size: None,
+            payload_size: 100,
+            timeout: 60,
         }
     }
 }
 
 pub fn get_configuration() -> Result<NailConfig> {
-    let config_dir = std::env::current_dir()?;
+    let config_dir = std::env::current_dir()?.join("configuration");
 
     let config = config::Config::builder()
+        .add_source(
+            config::File::from(config_dir.join("pit.default.toml"))
+                .format(config::FileFormat::Toml),
+        )
         .add_source(
             config::File::from(config_dir.join("pit.toml")).format(config::FileFormat::Toml),
         )
         .add_source(
             config::Environment::with_prefix("PIT")
                 .prefix_separator("__")
-                .separator("_"),
+                .separator("__"),
         )
         .build()?;
 
-    Ok(config.try_deserialize().unwrap_or_default())
+    Ok(config.try_deserialize()?)
 }

--- a/src/html_gen.rs
+++ b/src/html_gen.rs
@@ -7,16 +7,20 @@ use std::iter::repeat_with;
 
 use crate::{INTERNER, state::AppConfig};
 
+/// Provides either the minimum configured size, or a randomised value between
+/// the minimum and maximum configured sizes if a maximum is available.
 pub fn get_desired_size(config: &AppConfig, rng: &mut impl RngCore) -> usize {
-    let min_size = config.generator.min_size;
-    let max_size = config.generator.max_size;
-
-    match (min_size, max_size) {
+    match (
+        config.generator.min_paragraph_size,
+        config.generator.max_paragraph_size,
+    ) {
         (min, None) => min,
         (min, Some(max)) => rng.random_range(min..=max),
     }
 }
 
+/// Generates text from the markov chain, using the tokens it outputs to pull
+/// interned text from the interner.
 fn text_generator<'a>(
     interner: &'a Interner,
     chain: &'a NailKov,

--- a/src/html_gen.rs
+++ b/src/html_gen.rs
@@ -5,7 +5,17 @@ use nailkov::{NailKov, interner::Interner};
 use rand::{Rng, RngCore, distr::Alphanumeric};
 use std::iter::repeat_with;
 
-use crate::INTERNER;
+use crate::{INTERNER, state::AppConfig};
+
+pub fn get_desired_size(config: &AppConfig, rng: &mut impl RngCore) -> usize {
+    let min_size = config.generator.min_size;
+    let max_size = config.generator.max_size;
+
+    match (min_size, max_size) {
+        (min, None) => min,
+        (min, Some(max)) => rng.random_range(min..=max),
+    }
+}
 
 fn text_generator<'a>(
     interner: &'a Interner,
@@ -19,7 +29,7 @@ fn text_generator<'a>(
         .take(size)
 }
 
-pub fn title(chain: &NailKov, size: usize, rng: &mut impl RngCore) -> (Bytes, Bytes) {
+pub fn title(chain: &NailKov, config: &AppConfig, rng: &mut impl RngCore) -> (Bytes, Bytes) {
     let interner = INTERNER.read();
 
     let title_text: String = text_generator(&interner, chain, 24, rng).collect();
@@ -41,7 +51,7 @@ pub fn title(chain: &NailKov, size: usize, rng: &mut impl RngCore) -> (Bytes, By
     let max_paras: u32 = rng.random_range(1..=3);
 
     for _ in 0..max_paras {
-        header.extend(paragraph(chain, size, rng));
+        header.extend(paragraph(chain, get_desired_size(config, rng), rng));
     }
 
     (title.freeze(), header.freeze())

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,12 +12,18 @@ mod shutdown;
 mod state;
 
 use std::{
+    convert::Infallible,
     net::SocketAddr,
     sync::{Arc, LazyLock},
     time::{Duration, Instant},
 };
 
-use axum::http::HeaderValue;
+use axum::{
+    extract::Request,
+    http::HeaderValue,
+    response::Response,
+    serve::{IncomingStream, Listener},
+};
 use color_eyre::Result;
 use config::{NailConfig, get_configuration};
 use futures_concurrency::future::{Race, TryJoin};
@@ -32,6 +38,7 @@ use scc::HashMap;
 use shutdown::{shutdown_task, wait_for_shutdown};
 use state::ServerState;
 use tokio::time::interval_at;
+use tower::Service;
 use wyrand::RandomWyHashState;
 static INDEX: &str = include_str!("../templates/warning.html");
 
@@ -69,43 +76,22 @@ async fn nailpit_cleanup(state: ServerState) {
     }
 }
 
-async fn nailpit_axum(
-    state: ServerState,
-    shutdown_notifier: Arc<tokio::sync::watch::Sender<()>>,
-) -> Result<()> {
-    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await?;
-    let health_listener = tokio::net::TcpListener::bind("0.0.0.0:3001").await?;
-
-    log::info!(
-        "listening on http://{} & http://{}/health",
-        listener.local_addr()?,
-        health_listener.local_addr()?
-    );
-
-    let app = nail_app(state);
-
-    let generator_app = async {
-        tokio::spawn(
-            axum::serve(
-                listener,
-                app.into_make_service_with_connect_info::<SocketAddr>(),
-            )
-            .with_graceful_shutdown(wait_for_shutdown(shutdown_notifier.clone()))
+async fn spawn_axum_task<L, M, S, F>(listener: L, app: M, shutdown: F) -> Result<()>
+where
+    L: Listener,
+    L::Addr: core::fmt::Debug,
+    M: for<'a> Service<IncomingStream<'a, L>, Error = Infallible, Response = S> + Send + 'static,
+    for<'a> <M as Service<IncomingStream<'a, L>>>::Future: Send,
+    S: Service<Request, Response = Response, Error = Infallible> + Clone + Send + 'static,
+    S::Future: Send,
+    F: Future<Output = ()> + Send + 'static,
+{
+    tokio::spawn(
+        axum::serve(listener, app)
+            .with_graceful_shutdown(shutdown)
             .into_future(),
-        )
-        .await?
-    };
-
-    let health_app = async {
-        tokio::spawn(
-            axum::serve(health_listener, nail_health())
-                .with_graceful_shutdown(wait_for_shutdown(shutdown_notifier.clone()))
-                .into_future(),
-        )
-        .await?
-    };
-
-    (generator_app, health_app).try_join().await?;
+    )
+    .await??;
 
     Ok(())
 }
@@ -121,6 +107,15 @@ async fn nailpit_main(config: Arc<NailConfig>) -> Result<()> {
         config,
     );
 
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await?;
+    let health_listener = tokio::net::TcpListener::bind("0.0.0.0:3001").await?;
+
+    log::info!(
+        "listening on http://{} & http://{}/health",
+        listener.local_addr()?,
+        health_listener.local_addr()?
+    );
+
     tokio::spawn(
         (
             wait_for_shutdown(shutdown_notifier.clone()),
@@ -130,10 +125,19 @@ async fn nailpit_main(config: Arc<NailConfig>) -> Result<()> {
     );
 
     (
-        nailpit_axum(state, shutdown_notifier),
+        spawn_axum_task(
+            listener,
+            nail_app(state).into_make_service_with_connect_info::<SocketAddr>(),
+            wait_for_shutdown(shutdown_notifier.clone()),
+        ),
+        spawn_axum_task(
+            health_listener,
+            nail_health(),
+            wait_for_shutdown(shutdown_notifier),
+        ),
         shutdown_task(shutdown_signal),
     )
-        .race()
+        .try_join()
         .await?;
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::undocumented_unsafe_blocks)]
 
 mod body_stream;
+mod config;
 mod fv_parser;
 mod html_gen;
 mod markov;
@@ -18,6 +19,7 @@ use std::{
 
 use axum::http::HeaderValue;
 use color_eyre::Result;
+use config::{NailConfig, get_configuration};
 use futures_concurrency::future::{Race, TryJoin};
 use hyper::{HeaderMap, header::CONTENT_TYPE};
 use logforth::append;
@@ -26,9 +28,11 @@ use markov::MarkovGen;
 use nailkov::interner::Interner;
 use parking_lot::RwLock;
 use routes::{nail_app, nail_health};
+use scc::HashMap;
 use shutdown::{shutdown_task, wait_for_shutdown};
 use state::ServerState;
 use tokio::time::interval_at;
+use wyrand::RandomWyHashState;
 static INDEX: &str = include_str!("../templates/warning.html");
 
 const SOURCE_TIMEOUT: Duration = Duration::from_secs(60 * 2);
@@ -45,7 +49,7 @@ static GEN_HEADER: LazyLock<HeaderMap> = LazyLock::new(|| {
 static INTERNER: LazyLock<Arc<RwLock<Interner>>> = LazyLock::new(Default::default);
 
 static MARKOV: LazyLock<MarkovGen> =
-    LazyLock::new(|| MarkovGen::new(256, "./input/markov.txt").unwrap());
+    LazyLock::new(|| MarkovGen::new("./input/markov.txt").unwrap());
 
 #[fastrace::trace]
 async fn nailpit_cleanup(state: ServerState) {
@@ -106,10 +110,16 @@ async fn nailpit_axum(
     Ok(())
 }
 
-async fn nailpit_main() -> Result<()> {
+async fn nailpit_main(config: Arc<NailConfig>) -> Result<()> {
     let (shutdown_notifier, shutdown_signal) = tokio::sync::watch::channel(());
     let shutdown_notifier = Arc::new(shutdown_notifier);
-    let state = ServerState::default();
+    let state = ServerState::new(
+        Arc::new(HashMap::with_capacity_and_hasher(
+            128,
+            RandomWyHashState::new(),
+        )),
+        config,
+    );
 
     tokio::spawn(
         (
@@ -148,6 +158,10 @@ fn main() -> Result<()> {
 
     log::info!("Welcome to Nailpit!");
 
+    let config: NailConfig = get_configuration()?;
+
+    log::info!("Loaded config: {:?}", config);
+
     LazyLock::force(&MARKOV);
 
     let rt = tokio::runtime::Builder::new_multi_thread()
@@ -155,7 +169,7 @@ fn main() -> Result<()> {
         .enable_all()
         .build()?;
 
-    rt.block_on(nailpit_main())?;
+    rt.block_on(nailpit_main(Arc::new(config)))?;
 
     log::info!("Waiting for background tasks to complete...");
 

--- a/src/markov.rs
+++ b/src/markov.rs
@@ -2,10 +2,11 @@ use std::{path::Path, sync::Arc};
 
 use bytes::{Bytes, BytesMut};
 use color_eyre::Result;
-use futures_lite::Stream;
+use fastrace::{Span, future::FutureExt};
 use nailkov::NailKov;
 use rand::{Rng, RngCore};
 use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
 
 use crate::{
     INTERNER,
@@ -49,12 +50,12 @@ impl MarkovGen {
             buffer.extend(header(chain, 24, rng));
 
             for _ in 0..max_paras {
-                buffer.extend(paragraph(chain, get_desired_size(&config, rng), rng));
+                buffer.extend(paragraph(chain, get_desired_size(config, rng), rng));
             }
         }
     }
 
-    #[fastrace::trace]
+    #[fastrace::trace(enter_on_poll = true)]
     async fn spawn_generator(self, tx: mpsc::Sender<Bytes>, config: AppConfig) {
         let mut bytes_written = 0_usize;
         let start_time = std::time::Instant::now();
@@ -94,8 +95,8 @@ impl MarkovGen {
             return;
         };
 
-        let time_limit_duration = std::time::Duration::from_secs(60);
-        let size_limit = 1024 * 1024;
+        let time_limit_duration = std::time::Duration::from_secs(config.generator.timeout);
+        let size_limit = 1024 * config.generator.payload_size;
         loop {
             if time_limit_duration.as_secs() != 0 && (start_time.elapsed() > time_limit_duration) {
                 log::info!(
@@ -135,11 +136,14 @@ impl MarkovGen {
     }
 
     #[fastrace::trace]
-    pub fn into_stream(self, config: AppConfig) -> impl Stream<Item = Bytes> {
+    pub fn into_stream(self, config: AppConfig) -> ReceiverStream<Bytes> {
         let (tx, rx) = mpsc::channel::<Bytes>(8);
 
-        tokio::spawn(self.spawn_generator(tx, config));
+        tokio::spawn(
+            self.spawn_generator(tx, config)
+                .in_span(Span::enter_with_local_parent("Markov Generator")),
+        );
 
-        tokio_stream::wrappers::ReceiverStream::new(rx)
+        ReceiverStream::new(rx)
     }
 }

--- a/src/markov.rs
+++ b/src/markov.rs
@@ -9,19 +9,19 @@ use tokio::sync::mpsc;
 
 use crate::{
     INTERNER,
-    html_gen::{footer, header, paragraph, title},
+    html_gen::{footer, get_desired_size, header, paragraph, title},
     rng::FastRng,
+    state::AppConfig,
 };
 
 #[derive(Debug, Clone)]
 pub struct MarkovGen {
     chain: Arc<NailKov>,
-    size: usize,
 }
 
 impl MarkovGen {
     #[fastrace::trace]
-    pub fn new(size: usize, input: impl AsRef<Path>) -> Result<Self> {
+    pub fn new(input: impl AsRef<Path>) -> Result<Self> {
         let file = std::fs::read_to_string(input.as_ref())?;
 
         let mut interner_write_lock = INTERNER.write();
@@ -30,10 +30,10 @@ impl MarkovGen {
 
         drop(interner_write_lock);
 
-        Ok(Self { chain, size })
+        Ok(Self { chain })
     }
 
-    fn generate(chain: &NailKov, desired_size: usize, rng: &mut impl RngCore) -> Bytes {
+    fn generate(chain: &NailKov, config: &AppConfig, rng: &mut impl RngCore) -> Bytes {
         let mut buffer = BytesMut::with_capacity(8192);
 
         loop {
@@ -49,19 +49,18 @@ impl MarkovGen {
             buffer.extend(header(chain, 24, rng));
 
             for _ in 0..max_paras {
-                buffer.extend(paragraph(chain, desired_size, rng));
+                buffer.extend(paragraph(chain, get_desired_size(&config, rng), rng));
             }
         }
     }
 
     #[fastrace::trace]
-    async fn spawn_generator(self, tx: mpsc::Sender<Bytes>) {
+    async fn spawn_generator(self, tx: mpsc::Sender<Bytes>, config: AppConfig) {
         let mut bytes_written = 0_usize;
         let start_time = std::time::Instant::now();
-        let desired_size = self.size.max(128);
         let mut rng = FastRng::default();
 
-        let (title, content) = title(self.chain.as_ref(), desired_size, &mut rng);
+        let (title, content) = title(self.chain.as_ref(), &config, &mut rng);
 
         // For the first payload we want to make it look like an HTML page.
         // We want to ensure it has a unique title that matches the article header, so to
@@ -106,7 +105,7 @@ impl MarkovGen {
                 break;
             }
 
-            let content = MarkovGen::generate(self.chain.as_ref(), desired_size, &mut rng);
+            let content = MarkovGen::generate(self.chain.as_ref(), &config, &mut rng);
 
             let content_size = content.len();
 
@@ -136,10 +135,10 @@ impl MarkovGen {
     }
 
     #[fastrace::trace]
-    pub fn into_stream(self) -> impl Stream<Item = Bytes> {
+    pub fn into_stream(self, config: AppConfig) -> impl Stream<Item = Bytes> {
         let (tx, rx) = mpsc::channel::<Bytes>(8);
 
-        tokio::spawn(self.spawn_generator(tx));
+        tokio::spawn(self.spawn_generator(tx, config));
 
         tokio_stream::wrappers::ReceiverStream::new(rx)
     }

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -13,7 +13,7 @@ use tower_http::{compression::CompressionLayer, normalize_path::NormalizePathLay
 use crate::{
     GEN_HEADER, INDEX, MARKOV,
     body_stream::BodyStream,
-    state::{ServerState, track_incoming_sources},
+    state::{AppConfig, ServerState, track_incoming_sources},
 };
 
 #[fastrace::trace]
@@ -22,12 +22,12 @@ async fn handler() -> Html<&'static str> {
 }
 
 #[fastrace::trace]
-async fn generated() -> impl IntoResponse {
-    BodyStream::from_stream(MARKOV.clone().into_stream()).headers(GEN_HEADER.clone())
+async fn generated(config: AppConfig) -> impl IntoResponse {
+    BodyStream::from_stream(MARKOV.clone().into_stream(config)).headers(GEN_HEADER.clone())
 }
 
 pub fn nail_app(state: ServerState) -> Router {
-    nail_route().layer(
+    nail_route(state.clone()).layer(
         ServiceBuilder::new()
             .layer(fastrace_axum::FastraceLayer)
             .layer(HandleErrorLayer::new(|err: BoxError| async move {
@@ -47,10 +47,11 @@ pub fn nail_app(state: ServerState) -> Router {
     )
 }
 
-pub fn nail_route() -> Router {
-    Router::new()
-        .route("/", get(handler))
-        .nest("/private", Router::new().fallback(get(generated)))
+pub fn nail_route(state: ServerState) -> Router {
+    Router::new().route("/", get(handler)).nest(
+        "/private",
+        Router::new().fallback(get(generated)).with_state(state),
+    )
 }
 
 pub fn nail_health() -> Router {

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,5 @@
 use std::{
+    convert::Infallible,
     net::IpAddr,
     ops::{Deref, DerefMut},
     sync::Arc,
@@ -14,7 +15,7 @@ use hyper::StatusCode;
 use scc::HashMap;
 use wyrand::RandomWyHashState;
 
-use crate::peer::ProxiedPeer;
+use crate::{config::NailConfig, peer::ProxiedPeer};
 
 #[derive(Debug, Clone)]
 pub struct SourceState {
@@ -49,24 +50,47 @@ impl DerefMut for SourceMap {
 }
 
 #[derive(Debug, Clone)]
+pub struct AppConfig(Arc<NailConfig>);
+
+impl From<Arc<NailConfig>> for AppConfig {
+    #[inline]
+    fn from(value: Arc<NailConfig>) -> Self {
+        Self(value)
+    }
+}
+
+impl Deref for AppConfig {
+    type Target = NailConfig;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct ServerState {
     pub sources: SourceMap,
+    pub config: AppConfig,
 }
 
 impl ServerState {
-    pub fn new(sources: impl Into<SourceMap>) -> Self {
+    pub fn new(sources: impl Into<SourceMap>, config: impl Into<AppConfig>) -> Self {
         Self {
             sources: sources.into(),
+            config: config.into(),
         }
     }
 }
 
 impl Default for ServerState {
     fn default() -> Self {
-        Self::new(Arc::new(HashMap::with_capacity_and_hasher(
-            128,
-            RandomWyHashState::new(),
-        )))
+        Self::new(
+            Arc::new(HashMap::with_capacity_and_hasher(
+                128,
+                RandomWyHashState::new(),
+            )),
+            Arc::new(Default::default()),
+        )
     }
 }
 
@@ -77,12 +101,19 @@ impl FromRef<ServerState> for SourceMap {
     }
 }
 
+impl FromRef<ServerState> for AppConfig {
+    #[inline]
+    fn from_ref(input: &ServerState) -> Self {
+        input.config.clone()
+    }
+}
+
 impl<S> FromRequestParts<S> for SourceMap
 where
     SourceMap: FromRef<S>,
     S: Send + Sync,
 {
-    type Rejection = (StatusCode, &'static str);
+    type Rejection = Infallible;
 
     #[fastrace::trace]
     async fn from_request_parts(
@@ -90,6 +121,21 @@ where
         state: &S,
     ) -> Result<Self, Self::Rejection> {
         Ok(SourceMap::from_ref(state))
+    }
+}
+
+impl<S> FromRequestParts<S> for AppConfig
+where
+    AppConfig: FromRef<S>,
+    S: Send + Sync,
+{
+    type Rejection = Infallible;
+
+    async fn from_request_parts(
+        _parts: &mut axum::http::request::Parts,
+        state: &S,
+    ) -> Result<Self, Self::Rejection> {
+        Ok(AppConfig::from_ref(state))
     }
 }
 


### PR DESCRIPTION
Add configuration capability from toml files or from env variables. The user configurable file is `pit.toml`, while the defaults is provided by `pit.default.toml`. Environment variable format takes the form of `PIT__GENERATOR__TIMEOUT` for example.

Related #8 