### PR TITLE
Input files configuration for generation options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,9 +49,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "async-compression"
@@ -477,10 +477,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
-name = "h2"
-version = "0.4.8"
+name = "glob"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
+name = "h2"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75249d144030531f8dee69fe9cea04d3edf809a017ae445e2abdff6629e86633"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -619,9 +625,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f33145a5cbea837164362c7bd596106eb7c5198f97d1ba6f6ebb3223952e488"
+checksum = "e5ad87c89110f55e4cd4dc2893a9790820206729eaf221555f742d540b0724a0"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
@@ -634,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ce13c40ec6956157a3635d97a1ee2df323b263f09ea14165131289cb0f5c19"
+checksum = "d076d5b64a7e2fe6f0743f02c43ca4a6725c0f904203bfe276a5b3e793103605"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -686,9 +692,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libm"
@@ -822,6 +828,7 @@ dependencies = [
  "futures-concurrency",
  "futures-lite",
  "getrandom",
+ "glob",
  "hyper",
  "hyper-util",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ tower-http = { version = "0.6.2", features = [
 serde.workspace = true
 serde-aux = { version = "4.5.0", default-features = false }
 config = { version = "0.15.11", default-features = false, features = ["toml"] }
+glob = "0.3.2"
 
 [profile.release]
 codegen-units = 1

--- a/configuration/pit.default.toml
+++ b/configuration/pit.default.toml
@@ -1,4 +1,5 @@
 [generator]
+input_files = "input/*.txt"
 min_paragraph_size = 128
 max_paragraph_size = 256
 payload_size = 100

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,13 +3,14 @@ use serde_aux::field_attributes::{
     deserialize_number_from_string, deserialize_option_number_from_string,
 };
 
-#[derive(Debug, Default, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub struct NailConfig {
     pub generator: GeneratorConfig,
 }
 
 #[derive(Debug, serde::Deserialize)]
 pub struct GeneratorConfig {
+    pub input_files: String,
     #[serde(deserialize_with = "deserialize_number_from_string")]
     pub min_paragraph_size: usize,
     #[serde(deserialize_with = "deserialize_option_number_from_string")]
@@ -18,17 +19,6 @@ pub struct GeneratorConfig {
     pub payload_size: usize,
     #[serde(deserialize_with = "deserialize_number_from_string")]
     pub timeout: u64,
-}
-
-impl Default for GeneratorConfig {
-    fn default() -> Self {
-        Self {
-            min_paragraph_size: 128,
-            max_paragraph_size: None,
-            payload_size: 100,
-            timeout: 60,
-        }
-    }
 }
 
 pub fn get_configuration() -> Result<NailConfig> {

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -1,0 +1,24 @@
+use std::sync::Arc;
+
+use glob::glob;
+
+use crate::{config::NailConfig, markov::MarkovGen};
+
+/// Takes a glob for finding all input files and returns a read-only list of
+/// all markov chains that can be generated.
+pub fn get_input_files(config: &NailConfig) -> color_eyre::Result<Arc<[MarkovGen]>> {
+    let inputs = glob(&config.generator.input_files)?
+        .filter_map(|path| path.inspect_err(|err| log::error!("IO Error: {err}")).ok())
+        .filter_map(|input| {
+            MarkovGen::new(input)
+                .inspect_err(|err| log::error!("Markov Error: {err}"))
+                .ok()
+        })
+        .collect::<Arc<[MarkovGen]>>();
+
+    if inputs.is_empty() {
+        color_eyre::eyre::bail!("No input files found! Exiting...");
+    }
+
+    Ok(inputs)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod body_stream;
 mod config;
 mod fv_parser;
 mod html_gen;
+mod inputs;
 mod markov;
 mod peer;
 mod rng;
@@ -28,6 +29,7 @@ use color_eyre::Result;
 use config::{NailConfig, get_configuration};
 use futures_concurrency::future::{Race, TryJoin};
 use hyper::{HeaderMap, header::CONTENT_TYPE};
+use inputs::get_input_files;
 use logforth::append;
 use logforth::filter::EnvFilter;
 use markov::MarkovGen;
@@ -54,9 +56,6 @@ static GEN_HEADER: LazyLock<HeaderMap> = LazyLock::new(|| {
 });
 
 static INTERNER: LazyLock<Arc<RwLock<Interner>>> = LazyLock::new(Default::default);
-
-static MARKOV: LazyLock<MarkovGen> =
-    LazyLock::new(|| MarkovGen::new("./input/markov.txt").unwrap());
 
 #[fastrace::trace]
 async fn nailpit_cleanup(state: ServerState) {
@@ -96,7 +95,7 @@ where
     Ok(())
 }
 
-async fn nailpit_main(config: Arc<NailConfig>) -> Result<()> {
+async fn nailpit_main(config: Arc<NailConfig>, inputs: Arc<[MarkovGen]>) -> Result<()> {
     let (shutdown_notifier, shutdown_signal) = tokio::sync::watch::channel(());
     let shutdown_notifier = Arc::new(shutdown_notifier);
     let state = ServerState::new(
@@ -105,6 +104,7 @@ async fn nailpit_main(config: Arc<NailConfig>) -> Result<()> {
             RandomWyHashState::new(),
         )),
         config,
+        inputs,
     );
 
     let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await?;
@@ -166,14 +166,14 @@ fn main() -> Result<()> {
 
     log::info!("Loaded config: {:?}", config);
 
-    LazyLock::force(&MARKOV);
+    let inputs = get_input_files(&config)?;
 
     let rt = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(std::thread::available_parallelism()?.get().min(4))
         .enable_all()
         .build()?;
 
-    rt.block_on(nailpit_main(Arc::new(config)))?;
+    rt.block_on(nailpit_main(Arc::new(config), inputs))?;
 
     log::info!("Waiting for background tasks to complete...");
 

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -11,8 +11,9 @@ use tower::{ServiceBuilder, buffer::BufferLayer, limit::RateLimitLayer};
 use tower_http::{compression::CompressionLayer, normalize_path::NormalizePathLayer};
 
 use crate::{
-    GEN_HEADER, INDEX, MARKOV,
+    GEN_HEADER, INDEX,
     body_stream::BodyStream,
+    markov::MarkovGen,
     state::{AppConfig, ServerState, track_incoming_sources},
 };
 
@@ -22,8 +23,8 @@ async fn handler() -> Html<&'static str> {
 }
 
 #[fastrace::trace]
-async fn generated(config: AppConfig) -> impl IntoResponse {
-    BodyStream::from_stream(MARKOV.clone().into_stream(config)).headers(GEN_HEADER.clone())
+async fn generated(config: AppConfig, input: MarkovGen) -> impl IntoResponse {
+    BodyStream::from_stream(input.into_stream(config)).headers(GEN_HEADER.clone())
 }
 
 pub fn nail_app(state: ServerState) -> Router {

--- a/src/state.rs
+++ b/src/state.rs
@@ -14,36 +14,71 @@ use axum::{
 use hyper::StatusCode;
 use scc::HashMap;
 use wyrand::RandomWyHashState;
+use rand::seq::IndexedRandom;
 
-use crate::{config::NailConfig, peer::ProxiedPeer};
+use crate::{config::NailConfig, markov::MarkovGen, peer::ProxiedPeer, rng::FastRng};
 
+/// Smart pointer for all available Markov chains.
 #[derive(Debug, Clone)]
-pub struct SourceState {
-    visited: usize,
-    pub last_seen: Instant,
+pub struct NailInputs(Arc<[MarkovGen]>);
+
+impl NailInputs {
+    /// Pulls a random markov chain from the available list. Returns a cloned
+    /// pointer to the selected chain.
+    pub fn get_random_input(&self) -> MarkovGen {
+        assert!(!self.0.is_empty());
+
+        if self.0.len() == 1 {
+            self.0[0].clone()
+        } else {
+            let mut rng = FastRng::default();
+
+            self.0.choose(&mut rng).unwrap().clone()
+        }
+    }
 }
 
-type ShardedSources = Arc<HashMap<IpAddr, SourceState, RandomWyHashState>>;
-
-#[derive(Debug, Clone)]
-pub struct SourceMap(ShardedSources);
-
-impl From<ShardedSources> for SourceMap {
-    #[inline]
-    fn from(value: ShardedSources) -> Self {
+impl From<Arc<[MarkovGen]>> for NailInputs {
+    fn from(value: Arc<[MarkovGen]>) -> Self {
         Self(value)
     }
 }
 
-impl Deref for SourceMap {
-    type Target = ShardedSources;
+impl Deref for NailInputs {
+    type Target = [MarkovGen];
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PeerState {
+    visited: usize,
+    pub last_seen: Instant,
+}
+
+type ShardedPeers = Arc<HashMap<IpAddr, PeerState, RandomWyHashState>>;
+
+#[derive(Debug, Clone)]
+pub struct PeerMap(ShardedPeers);
+
+impl From<ShardedPeers> for PeerMap {
+    #[inline]
+    fn from(value: ShardedPeers) -> Self {
+        Self(value)
+    }
+}
+
+impl Deref for PeerMap {
+    type Target = ShardedPeers;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl DerefMut for SourceMap {
+impl DerefMut for PeerMap {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
@@ -69,32 +104,26 @@ impl Deref for AppConfig {
 
 #[derive(Debug, Clone)]
 pub struct ServerState {
-    pub sources: SourceMap,
+    pub sources: PeerMap,
     pub config: AppConfig,
+    pub inputs: NailInputs,
 }
 
 impl ServerState {
-    pub fn new(sources: impl Into<SourceMap>, config: impl Into<AppConfig>) -> Self {
+    pub fn new(
+        sources: impl Into<PeerMap>,
+        config: impl Into<AppConfig>,
+        inputs: impl Into<NailInputs>,
+    ) -> Self {
         Self {
             sources: sources.into(),
             config: config.into(),
+            inputs: inputs.into(),
         }
     }
 }
 
-impl Default for ServerState {
-    fn default() -> Self {
-        Self::new(
-            Arc::new(HashMap::with_capacity_and_hasher(
-                128,
-                RandomWyHashState::new(),
-            )),
-            Arc::new(Default::default()),
-        )
-    }
-}
-
-impl FromRef<ServerState> for SourceMap {
+impl FromRef<ServerState> for PeerMap {
     #[inline]
     fn from_ref(input: &ServerState) -> Self {
         input.sources.clone()
@@ -108,9 +137,16 @@ impl FromRef<ServerState> for AppConfig {
     }
 }
 
-impl<S> FromRequestParts<S> for SourceMap
+impl FromRef<ServerState> for NailInputs {
+    #[inline]
+    fn from_ref(input: &ServerState) -> Self {
+        input.inputs.clone()
+    }
+}
+
+impl<S> FromRequestParts<S> for PeerMap
 where
-    SourceMap: FromRef<S>,
+    PeerMap: FromRef<S>,
     S: Send + Sync,
 {
     type Rejection = Infallible;
@@ -120,7 +156,7 @@ where
         _parts: &mut axum::http::request::Parts,
         state: &S,
     ) -> Result<Self, Self::Rejection> {
-        Ok(SourceMap::from_ref(state))
+        Ok(PeerMap::from_ref(state))
     }
 }
 
@@ -131,6 +167,7 @@ where
 {
     type Rejection = Infallible;
 
+    #[fastrace::trace]
     async fn from_request_parts(
         _parts: &mut axum::http::request::Parts,
         state: &S,
@@ -139,9 +176,27 @@ where
     }
 }
 
+impl<S> FromRequestParts<S> for MarkovGen
+where
+    NailInputs: FromRef<S>,
+    S: Send + Sync,
+{
+    type Rejection = Infallible;
+
+    #[fastrace::trace]
+    async fn from_request_parts(
+        _parts: &mut axum::http::request::Parts,
+        state: &S,
+    ) -> Result<Self, Self::Rejection> {
+        let markov = NailInputs::from_ref(state);
+
+        Ok(markov.get_random_input())
+    }
+}
+
 #[fastrace::trace]
 pub async fn track_incoming_sources(
-    sources: SourceMap,
+    sources: PeerMap,
     proxied: ProxiedPeer,
     request: Request,
     next: Next,
@@ -155,7 +210,7 @@ pub async fn track_incoming_sources(
             source.visited += 1;
             source.last_seen = Instant::now()
         })
-        .or_insert_with(|| SourceState {
+        .or_insert_with(|| PeerState {
             visited: 1,
             last_seen: Instant::now(),
         });


### PR DESCRIPTION
This adds the ability to configure where input texts for training the markov chains are located. The configuration allows for many different chains to be constructed, with the idea of a page having a random chain granted to it to generate garbage text of different "flavours". The configuration for this is done with `glob`, so a user can define the directory structure and text files to load and train.

This means the markov chains are now kept as "state" on the server, and instead are provided by request handlers on demand.