### PR TITLE
Route & Socket configuration

### DIFF
--- a/configuration/pit.default.toml
+++ b/configuration/pit.default.toml
@@ -1,3 +1,6 @@
+pit_routes = ["/private"]
+socket_addr = "0.0.0.0:3000"
+
 [generator]
 input_files = "input/*.txt"
 min_paragraph_size = 128

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,8 @@ use serde_aux::field_attributes::{
 
 #[derive(Debug, serde::Deserialize)]
 pub struct NailConfig {
+    pub pit_routes: Vec<String>,
+    pub socket_addr: String,
     pub generator: GeneratorConfig,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,18 +13,12 @@ mod shutdown;
 mod state;
 
 use std::{
-    convert::Infallible,
     net::SocketAddr,
     sync::{Arc, LazyLock},
     time::{Duration, Instant},
 };
 
-use axum::{
-    extract::Request,
-    http::HeaderValue,
-    response::Response,
-    serve::{IncomingStream, Listener},
-};
+use axum::http::HeaderValue;
 use color_eyre::Result;
 use config::{NailConfig, get_configuration};
 use futures_concurrency::future::{Race, TryJoin};
@@ -35,12 +29,11 @@ use logforth::filter::EnvFilter;
 use markov::MarkovGen;
 use nailkov::interner::Interner;
 use parking_lot::RwLock;
-use routes::{nail_app, nail_health};
+use routes::nail_app;
 use scc::HashMap;
 use shutdown::{shutdown_task, wait_for_shutdown};
 use state::ServerState;
 use tokio::time::interval_at;
-use tower::Service;
 use wyrand::RandomWyHashState;
 static INDEX: &str = include_str!("../templates/warning.html");
 
@@ -75,20 +68,24 @@ async fn nailpit_cleanup(state: ServerState) {
     }
 }
 
-async fn spawn_axum_task<L, M, S, F>(listener: L, app: M, shutdown: F) -> Result<()>
+async fn spawn_axum_server<F>(
+    state: ServerState,
+    shutdown: F,
+) -> Result<()>
 where
-    L: Listener,
-    L::Addr: core::fmt::Debug,
-    M: for<'a> Service<IncomingStream<'a, L>, Error = Infallible, Response = S> + Send + 'static,
-    for<'a> <M as Service<IncomingStream<'a, L>>>::Future: Send,
-    S: Service<Request, Response = Response, Error = Infallible> + Clone + Send + 'static,
-    S::Future: Send,
     F: Future<Output = ()> + Send + 'static,
 {
+    let listener = tokio::net::TcpListener::bind(&state.config.socket_addr).await?;
+
+    log::info!("listening on http://{}", listener.local_addr()?,);
+
     tokio::spawn(
-        axum::serve(listener, app)
-            .with_graceful_shutdown(shutdown)
-            .into_future(),
+        axum::serve(
+            listener,
+            nail_app(state).into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .with_graceful_shutdown(shutdown)
+        .into_future(),
     )
     .await??;
 
@@ -107,15 +104,6 @@ async fn nailpit_main(config: Arc<NailConfig>, inputs: Arc<[MarkovGen]>) -> Resu
         inputs,
     );
 
-    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await?;
-    let health_listener = tokio::net::TcpListener::bind("0.0.0.0:3001").await?;
-
-    log::info!(
-        "listening on http://{} & http://{}/health",
-        listener.local_addr()?,
-        health_listener.local_addr()?
-    );
-
     tokio::spawn(
         (
             wait_for_shutdown(shutdown_notifier.clone()),
@@ -125,15 +113,9 @@ async fn nailpit_main(config: Arc<NailConfig>, inputs: Arc<[MarkovGen]>) -> Resu
     );
 
     (
-        spawn_axum_task(
-            listener,
-            nail_app(state).into_make_service_with_connect_info::<SocketAddr>(),
+        spawn_axum_server(
+            state,
             wait_for_shutdown(shutdown_notifier.clone()),
-        ),
-        spawn_axum_task(
-            health_listener,
-            nail_health(),
-            wait_for_shutdown(shutdown_notifier),
         ),
         shutdown_task(shutdown_signal),
     )

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,7 +115,7 @@ async fn nailpit_main(config: Arc<NailConfig>, inputs: Arc<[MarkovGen]>) -> Resu
     (
         spawn_axum_server(
             state,
-            wait_for_shutdown(shutdown_notifier.clone()),
+            wait_for_shutdown(shutdown_notifier),
         ),
         shutdown_task(shutdown_signal),
     )

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -28,33 +28,39 @@ async fn generated(config: AppConfig, input: MarkovGen) -> impl IntoResponse {
 }
 
 pub fn nail_app(state: ServerState) -> Router {
-    nail_route(state.clone()).layer(
-        ServiceBuilder::new()
-            .layer(fastrace_axum::FastraceLayer)
-            .layer(HandleErrorLayer::new(|err: BoxError| async move {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Unhandled Error: {err}"),
-                )
-            }))
-            .layer(BufferLayer::new(1024))
-            .layer(RateLimitLayer::new(1000, Duration::from_secs(60)))
-            .layer(NormalizePathLayer::trim_trailing_slash())
-            .layer(axum::middleware::from_fn_with_state(
-                state,
-                track_incoming_sources,
-            ))
-            .layer(CompressionLayer::new().quality(tower_http::CompressionLevel::Default)),
-    )
+    nail_route(state.clone())
+        .layer(
+            ServiceBuilder::new()
+                .layer(fastrace_axum::FastraceLayer)
+                .layer(HandleErrorLayer::new(|err: BoxError| async move {
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        format!("Unhandled Error: {err}"),
+                    )
+                }))
+                .layer(BufferLayer::new(1024))
+                .layer(RateLimitLayer::new(1000, Duration::from_secs(60)))
+                .layer(NormalizePathLayer::trim_trailing_slash())
+                .layer(axum::middleware::from_fn_with_state(
+                    state,
+                    track_incoming_sources,
+                ))
+                .layer(CompressionLayer::new().quality(tower_http::CompressionLevel::Default)),
+        )
+        .route("/health", get(async || StatusCode::NO_CONTENT))
 }
 
 pub fn nail_route(state: ServerState) -> Router {
-    Router::new().route("/", get(handler)).nest(
-        "/private",
-        Router::new().fallback(get(generated)).with_state(state),
-    )
-}
+    let index = Router::new().route("/", get(handler));
 
-pub fn nail_health() -> Router {
-    Router::new().route("/health", get(async || StatusCode::NO_CONTENT))
+    let pit = state
+        .config
+        .pit_routes
+        .iter()
+        .fold(Router::new(), |router, path| {
+            router.nest(path.as_str(), Router::new().fallback(get(generated)))
+        })
+        .with_state(state);
+
+    index.merge(pit)
 }


### PR DESCRIPTION
Merged the health route into the main app route so it reflects better the state of the application (if it returns a response, the main routes are doing fine), reducing the need for two ports to be used and making it just one port now. Along with this, I added configuration options for setting the routes for the pit, so one can have one or multiple customised routes (to better hide/obfuscate things to malicious crawlers. They blacklist one route, only to fall for the other). Also added was configuring the socket address that the server application listens to for HTTP requests, so to improve the hosting story for `nailpit`.