### PR TITLE
Use mimalloc for improved performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "color-eyre"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,6 +712,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
+name = "libmimalloc-sys2"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "584d72b26f578b3084461aa713f17237fc93d9a467844dd4df4a98d6fbbb6db0"
+dependencies = [
+ "cmake",
+ "libc",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,6 +783,15 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "mimalloc-safe"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "062d14d92efc78427be0f955459ac69c1e687e868784a7f55d27115c66cf739c"
+dependencies = [
+ "libmimalloc-sys2",
+]
 
 [[package]]
 name = "mime"
@@ -865,6 +893,7 @@ dependencies = [
  "hyper",
  "log",
  "logforth",
+ "mimalloc-safe",
  "nailconfig",
  "nailfv",
  "nailgen",
@@ -1085,9 +1114,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,9 @@ path = "src/main.rs"
 name = "nailpit"
 
 [features]
+default = ["mimalloc"]
 tracing = ["fastrace/enable"]
+mimalloc = ["dep:mimalloc-safe"]
 
 [dependencies]
 nailkov = { path = "nailkov" }
@@ -101,6 +103,7 @@ tower-http = { version = "0.6.2", features = [
 ] }
 serde.workspace = true
 glob = "0.3.2"
+mimalloc-safe = { version = "0.1.50", optional = true }
 
 [profile.release]
 codegen-units = 1

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,12 @@ use color_eyre::Result;
 use futures_concurrency::future::{Race, TryJoin};
 use logforth::append;
 use logforth::filter::EnvFilter;
+use mimalloc_safe::MiMalloc;
 use tokio::time::interval_at;
 use wyrand::RandomWyHashState;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 #[fastrace::trace]
 async fn nailpit_cleanup(state: nailpit::state::ServerState) {
@@ -51,7 +55,10 @@ where
     Ok(())
 }
 
-async fn nailpit_main(config: Arc<nailconfig::NailConfig>, inputs: Arc<[nailgen::MarkovGen]>) -> Result<()> {
+async fn nailpit_main(
+    config: Arc<nailconfig::NailConfig>,
+    inputs: Arc<[nailgen::MarkovGen]>,
+) -> Result<()> {
     let (shutdown_notifier, shutdown_signal) = tokio::sync::watch::channel(());
     let shutdown_notifier = Arc::new(shutdown_notifier);
     let state = nailpit::state::ServerState::new(


### PR DESCRIPTION
Adds a feature flag (enabled by default) to have `nailpit` make use of `mimalloc` as the global allocator instead of the system allocator. This is both a small perf improvement over the system allocator on glibc Linux, and a much larger improvement over the musl allocator.

To compile `nailpit` to use the system allocator instead, compile with `--no-default-features`.