### PR TITLE
Output limiting

### DIFF
--- a/configuration/pit.default.toml
+++ b/configuration/pit.default.toml
@@ -1,9 +1,15 @@
 pit_routes = ["/private"]
 socket_addr = "0.0.0.0:3000"
+worker_threads = 4
 
 [generator]
 input_files = "input/*.txt"
 min_paragraph_size = 128
 max_paragraph_size = 256
+max_pit_links = 4
+header_size = 32
 payload_size = 100
 timeout = 60
+min_delay = 0
+max_delay = 100
+chunk_size = 4096

--- a/nailconfig/src/lib.rs
+++ b/nailconfig/src/lib.rs
@@ -12,6 +12,8 @@ use serde_aux::field_attributes::{
 pub struct NailConfig {
     pub pit_routes: Vec<String>,
     pub socket_addr: String,
+    #[serde(deserialize_with = "deserialize_number_from_string")]
+    pub worker_threads: usize,
     pub generator: GeneratorConfig,
 }
 
@@ -26,6 +28,16 @@ pub struct GeneratorConfig {
     pub payload_size: usize,
     #[serde(deserialize_with = "deserialize_number_from_string")]
     pub timeout: u64,
+    #[serde(deserialize_with = "deserialize_number_from_string")]
+    pub min_delay: u64,
+    #[serde(deserialize_with = "deserialize_option_number_from_string")]
+    pub max_delay: Option<u64>,
+    #[serde(deserialize_with = "deserialize_number_from_string")]
+    pub chunk_size: usize,
+    #[serde(deserialize_with = "deserialize_number_from_string")]
+    pub header_size: usize,
+    #[serde(deserialize_with = "deserialize_number_from_string")]
+    pub max_pit_links: usize,
 }
 
 pub fn get_configuration() -> Result<NailConfig> {
@@ -37,7 +49,9 @@ pub fn get_configuration() -> Result<NailConfig> {
                 .format(config::FileFormat::Toml),
         )
         .add_source(
-            config::File::from(config_dir.join("pit.toml")).format(config::FileFormat::Toml),
+            config::File::from(config_dir.join("pit.toml"))
+                .required(false)
+                .format(config::FileFormat::Toml),
         )
         .add_source(
             config::Environment::with_prefix("PIT")

--- a/nailgen/src/delay.rs
+++ b/nailgen/src/delay.rs
@@ -1,0 +1,20 @@
+use std::time::Duration;
+
+use nailconfig::NailConfig;
+use rand::{RngCore, Rng};
+use tokio::time::sleep;
+
+/// Apply a delay/sleep based from provided configuration. Either it provides a set
+/// minimum delay, or a randomised value sampled from a range of the minimum and maximum
+/// configured delays. If the delay value is `0`, this future will poll ready immediately
+/// and no sleep will be invoked.
+pub async fn delay_output(config: &NailConfig, rng: &mut impl RngCore) {
+    let delay = match (config.generator.min_delay, config.generator.max_delay) {
+        (min_delay, None) => min_delay,
+        (min_delay, Some(max_delay)) => rng.random_range(min_delay..=max_delay),
+    };
+
+    if delay > 0 {
+        sleep(Duration::from_millis(delay)).await;
+    }
+}

--- a/nailgen/src/html_gen.rs
+++ b/nailgen/src/html_gen.rs
@@ -84,8 +84,8 @@ pub fn header(chain: &NailKov, size: usize, rng: &mut impl RngCore) -> Bytes {
     )
 }
 
-pub fn footer(route: &str, rng: &mut impl RngCore) -> Bytes {
-    let total_links = rng.random_range(1..=4);
+pub fn links(route: &str, max_links: usize, rng: &mut impl RngCore) -> Bytes {
+    let total_links = rng.random_range(1..=max_links);
 
     let link = repeat_with(|| {
         rng.sample_iter(Alphanumeric)
@@ -95,16 +95,25 @@ pub fn footer(route: &str, rng: &mut impl RngCore) -> Bytes {
     })
     .enumerate();
 
-    let mut footer = String::from("</article></main>\n<footer><nav><ul>");
+    let mut nav = String::from("<nav><ul>");
 
     for (i, link) in link.take(total_links) {
         let link = format!("<li><a href=\"{route}/{}\">{}</a></li>", link, i + 1);
-        footer = [footer, link].concat();
+        nav = [nav, link].concat();
     }
 
-    footer.push_str("</ul></nav></footer>\n</body>\n</html>");
+    nav.push_str("</ul></nav>");
 
-    Bytes::from(footer)
+    Bytes::from(nav)
+}
+
+pub fn footer(route: &str, max_links: usize, rng: &mut impl RngCore) -> Bytes {
+    let mut footer = BytesMut::from("</article></main>\n<footer>");
+
+    footer.extend(links(route, max_links, rng));
+    footer.extend(b"</footer>\n</body>\n</html>");
+
+    footer.freeze()
 }
 
 #[inline]

--- a/nailgen/src/lib.rs
+++ b/nailgen/src/lib.rs
@@ -4,7 +4,6 @@
 use std::{
     path::Path,
     sync::{Arc, LazyLock},
-    time::Duration,
 };
 
 use axum::extract::NestedPath;
@@ -16,25 +15,16 @@ use nailkov::{NailKov, interner::Interner};
 use nailrng::FastRng;
 use parking_lot::RwLock;
 use rand::{Rng, RngCore};
-use tokio::{sync::mpsc, time::sleep};
+use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 
+use crate::delay::delay_output;
 use crate::html_gen::{footer, get_desired_size, header, paragraph, title};
 
+mod delay;
 mod html_gen;
 
 static INTERNER: LazyLock<Arc<RwLock<Interner>>> = LazyLock::new(Default::default);
-
-async fn delay_output(config: &NailConfig, rng: &mut impl RngCore) {
-    let delay = match (config.generator.min_delay, config.generator.max_delay) {
-        (min_delay, None) => min_delay,
-        (min_delay, Some(max_delay)) => rng.random_range(min_delay..=max_delay),
-    };
-
-    if delay > 0 {
-        sleep(Duration::from_millis(delay)).await;
-    }
-}
 
 #[derive(Debug, Clone)]
 pub struct MarkovGen {

--- a/nailgen/src/lib.rs
+++ b/nailgen/src/lib.rs
@@ -4,6 +4,7 @@
 use std::{
     path::Path,
     sync::{Arc, LazyLock},
+    time::Duration,
 };
 
 use axum::extract::NestedPath;
@@ -15,7 +16,7 @@ use nailkov::{NailKov, interner::Interner};
 use nailrng::FastRng;
 use parking_lot::RwLock;
 use rand::{Rng, RngCore};
-use tokio::sync::mpsc;
+use tokio::{sync::mpsc, time::sleep};
 use tokio_stream::wrappers::ReceiverStream;
 
 use crate::html_gen::{footer, get_desired_size, header, paragraph, title};
@@ -23,6 +24,17 @@ use crate::html_gen::{footer, get_desired_size, header, paragraph, title};
 mod html_gen;
 
 static INTERNER: LazyLock<Arc<RwLock<Interner>>> = LazyLock::new(Default::default);
+
+async fn delay_output(config: &NailConfig, rng: &mut impl RngCore) {
+    let delay = match (config.generator.min_delay, config.generator.max_delay) {
+        (min_delay, None) => min_delay,
+        (min_delay, Some(max_delay)) => rng.random_range(min_delay..=max_delay),
+    };
+
+    if delay > 0 {
+        sleep(Duration::from_millis(delay)).await;
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct MarkovGen {
@@ -44,22 +56,23 @@ impl MarkovGen {
     }
 
     fn generate(chain: &NailKov, config: &NailConfig, rng: &mut impl RngCore) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(8192);
+        // Allocate more than we need, as we might generate more tokens than our 4kB threshold
+        let mut buffer = BytesMut::with_capacity(config.generator.chunk_size * 2);
 
         loop {
-            // We can generate more before handing it off to be streamed to the client,
-            // A bit more latency, but much more throughput, and friendlier to being compressed.
-            if buffer.len() >= 4096 {
-                return buffer.freeze();
-            }
-
             // Randomise how many paragraphs we want per section
             let max_paras: u32 = rng.random_range(1..=4);
 
-            buffer.extend(header(chain, 24, rng));
+            buffer.extend(header(chain, config.generator.header_size, rng));
 
             for _ in 0..max_paras {
                 buffer.extend(paragraph(chain, get_desired_size(config, rng), rng));
+            }
+
+            // We can generate more before handing it off to be streamed to the client,
+            // A bit more latency, but much more throughput, and friendlier to being compressed.
+            if buffer.len() >= config.generator.chunk_size {
+                return buffer.freeze();
             }
         }
     }
@@ -92,7 +105,8 @@ impl MarkovGen {
         initial_payload.extend(
             r#"    <meta charset="utf-8" />
     <meta name="robots" content="noindex, nofollow, nosnippet, noimageindex" />
-    <meta name="referrer" content="noreferrer">
+    <meta name="referrer" content="noreferrer" />
+    <meta name="color-theme" content="dark" />
 </head>
 <body><main><article>"#
                 .bytes(),
@@ -112,6 +126,8 @@ impl MarkovGen {
         let time_limit_duration = std::time::Duration::from_secs(config.generator.timeout);
         let size_limit = 1024 * config.generator.payload_size;
         loop {
+            delay_output(&config, &mut rng).await;
+
             if time_limit_duration.as_secs() != 0 && (start_time.elapsed() > time_limit_duration) {
                 log::info!(
                     "Time limit was reached ({} s), breaking stream",
@@ -144,7 +160,7 @@ impl MarkovGen {
             }
         }
 
-        let final_str = footer(path.as_str(), &mut rng);
+        let final_str = footer(path.as_str(), config.generator.max_pit_links, &mut rng);
 
         tx.send(final_str).await.ok();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,7 +117,11 @@ fn main() -> Result<()> {
     let inputs = nailpit::inputs::get_input_files(&config)?;
 
     let rt = tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(std::thread::available_parallelism()?.get().min(4))
+        .worker_threads(
+            std::thread::available_parallelism()?
+                .get()
+                .min(config.worker_threads),
+        )
         .enable_all()
         .build()?;
 


### PR DESCRIPTION
This PR adds some output/rate limiting features to nailpit, this one focused on adding additional configuration to allow tuning how quickly/slowly generated output to streamed to the client. This tuning helps to reduce pressure on the server when generating a lot of content at once, and keeps clients waiting for more content (as long as the connection is alive and data being received just often enough to not disconnect/terminate). The rate is defined by a min and max delay time in milliseconds, and the delay then is a random value between the two for each chunk that is delivered. This way, the delay isn't always super slow, and in theory prevents it looking too uniform/predictable.

The PR includes some extras like configuring the max worker threads being spawned, as well extra generation options.