### PR TITLE
Token optimisations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,9 +509,6 @@ name = "hashbrown"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
-dependencies = [
- "equivalent",
-]
 
 [[package]]
 name = "http"
@@ -854,7 +851,6 @@ dependencies = [
 name = "nailkov"
 version = "0.1.0"
 dependencies = [
- "hashbrown",
  "indexmap",
  "itertools",
  "log",

--- a/nailkov/Cargo.toml
+++ b/nailkov/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 rand.workspace = true
 rand_distr.workspace = true
 wyrand.workspace = true
-hashbrown.workspace = true
 itertools.workspace = true
 unicode-segmentation.workspace = true
 log.workspace = true

--- a/nailkov/src/distribution.rs
+++ b/nailkov/src/distribution.rs
@@ -2,7 +2,7 @@
 //! a [`TokenPair`](crate::token::TokenPair) in a [`NailKov`](crate::NailKov).
 
 use core::hash::BuildHasher;
-use hashbrown::HashMap;
+use indexmap::IndexMap;
 use rand::Rng;
 use rand_distr::{Distribution, weighted::WeightedAliasIndex};
 use wyrand::RandomWyHashState;
@@ -30,13 +30,13 @@ impl Distribution<Token> for TokenWeights {
 #[derive(Clone, Debug)]
 pub struct TokenWeightsBuilder<S = RandomWyHashState> {
     /// Counts how many times a token is likely to appear.
-    occurrences: HashMap<Token, u64, S>,
+    occurrences: IndexMap<Token, u64, S>,
 }
 
 impl<S: BuildHasher> TokenWeightsBuilder<S> {
     pub fn new(hasher: S) -> Self {
         Self {
-            occurrences: HashMap::with_hasher(hasher),
+            occurrences: IndexMap::with_hasher(hasher),
         }
     }
 

--- a/nailkov/src/interner.rs
+++ b/nailkov/src/interner.rs
@@ -4,6 +4,13 @@ use wyrand::RandomWyHashState;
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct InternedString(u32);
 
+impl InternedString {
+    #[inline(always)]
+    pub const fn to_bits(&self) -> u32 {
+        self.0
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct StringPtr(*const str);
 

--- a/nailkov/src/interner.rs
+++ b/nailkov/src/interner.rs
@@ -6,7 +6,7 @@ pub struct InternedString(u32);
 
 impl InternedString {
     #[inline(always)]
-    pub const fn to_bits(&self) -> u32 {
+    pub const fn to_bits(self) -> u32 {
         self.0
     }
 }

--- a/nailkov/src/lib.rs
+++ b/nailkov/src/lib.rs
@@ -36,7 +36,7 @@ impl<R: RngCore, S: BuildHasher> Iterator for NailKovIter<'_, R, S> {
     fn next(&mut self) -> Option<Self::Item> {
         let next_token = self.chain.generate_next_token(&mut self.rng, self.prev)?;
 
-        self.prev = TokenPair::new(self.prev.1, next_token);
+        self.prev = TokenPair::new(self.prev.right, next_token);
 
         Some(next_token)
     }

--- a/nailkov/src/lib.rs
+++ b/nailkov/src/lib.rs
@@ -7,7 +7,7 @@ pub mod interner;
 mod token;
 
 use error::NailError;
-use hashbrown::HashMap;
+use indexmap::IndexMap;
 use interner::Interner;
 use itertools::Itertools;
 use rand::{RngCore, seq::IteratorRandom};
@@ -21,7 +21,7 @@ use wyrand::RandomWyHashState;
 
 #[derive(Clone, Debug)]
 pub struct NailKov<S = RandomWyHashState> {
-    chain: HashMap<TokenPair, TokenWeights, S>,
+    chain: IndexMap<TokenPair, TokenWeights, S>,
 }
 
 pub struct NailKovIter<'a, R: RngCore, S = RandomWyHashState> {
@@ -88,13 +88,13 @@ impl<S: BuildHasher + Clone + Default> NailKov<S> {
 
 #[derive(Debug)]
 struct NailBuilder<S = RandomWyHashState> {
-    chain: HashMap<TokenPair, TokenWeightsBuilder<S>, S>,
+    chain: IndexMap<TokenPair, TokenWeightsBuilder<S>, S>,
 }
 
 impl<S: BuildHasher + Clone + Default> NailBuilder<S> {
     fn new(hasher: S) -> Self {
         Self {
-            chain: HashMap::with_hasher(hasher),
+            chain: IndexMap::with_hasher(hasher),
         }
     }
 
@@ -107,7 +107,7 @@ impl<S: BuildHasher + Clone + Default> NailBuilder<S> {
             return Err(NailError::EmptyInput);
         }
 
-        let chain: HashMap<TokenPair, TokenWeights, S> = self
+        let chain: IndexMap<TokenPair, TokenWeights, S> = self
             .chain
             .into_iter()
             .flat_map(|(pair, dist)| {

--- a/nailkov/src/token.rs
+++ b/nailkov/src/token.rs
@@ -17,6 +17,11 @@ impl Token {
     pub const fn id(&self) -> InternedString {
         self.0
     }
+
+    #[inline(always)]
+    pub const fn to_bits(self) -> u32 {
+        self.0.to_bits()
+    }
 }
 
 impl From<InternedString> for Token {
@@ -90,7 +95,7 @@ impl TokenPair {
 
     #[inline(always)]
     const fn to_bits(self) -> u64 {
-        self.left.id().to_bits() as u64 | ((self.right.id().to_bits() as u64) << 32)
+        self.left.to_bits() as u64 | ((self.right.to_bits() as u64) << 32)
     }
 }
 

--- a/nailkov/src/token.rs
+++ b/nailkov/src/token.rs
@@ -8,22 +8,26 @@ use crate::interner::InternedString;
 pub struct Token(InternedString);
 
 impl Token {
-    pub fn new(ptr: InternedString) -> Self {
+    #[inline(always)]
+    pub const fn new(ptr: InternedString) -> Self {
         Self(ptr)
     }
 
-    pub fn id(&self) -> InternedString {
+    #[inline(always)]
+    pub const fn id(&self) -> InternedString {
         self.0
     }
 }
 
 impl From<InternedString> for Token {
+    #[inline]
     fn from(value: InternedString) -> Self {
         Self::new(value)
     }
 }
 
 impl From<Token> for InternedString {
+    #[inline]
     fn from(value: Token) -> Self {
         value.id()
     }
@@ -38,12 +42,55 @@ impl Deref for Token {
 }
 
 /// An owned pair of [`Token`]s.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct TokenPair(pub Token, pub Token);
+#[derive(Copy, Clone, Debug)]
+// Alignment repr necessary to allow LLVM to better output
+// optimized codegen for `to_bits`, `PartialEq`
+// Prior art taken from my contribution to Bevy:
+// https://github.com/bevyengine/bevy/blob/main/crates/bevy_ecs/src/entity/mod.rs#L309
+#[repr(C, align(8))]
+pub struct TokenPair {
+    // Do not reorder the fields here. The ordering is explicitly used by repr(C)
+    // to make this struct equivalent to a u64.
+    #[cfg(target_endian = "little")]
+    pub left: Token,
+    pub right: Token,
+    #[cfg(target_endian = "big")]
+    pub left: Token,
+}
+
+// By not short-circuiting in comparisons, we get better codegen.
+// See <https://github.com/rust-lang/rust/issues/117800>
+impl PartialEq for TokenPair {
+    #[inline]
+    fn eq(&self, other: &TokenPair) -> bool {
+        // By using `to_bits`, the codegen can be optimized out even
+        // further potentially. Relies on the correct alignment/field
+        // order of `TokenPair`.
+        self.to_bits() == other.to_bits()
+    }
+}
+
+impl Eq for TokenPair {}
+
+impl core::hash::Hash for TokenPair {
+    #[inline]
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.to_bits().hash(state);
+    }
+}
 
 impl TokenPair {
+    #[inline]
     pub fn new<T: Into<Token>>(left: T, right: T) -> Self {
-        Self(left.into(), right.into())
+        Self {
+            left: left.into(),
+            right: right.into(),
+        }
+    }
+
+    #[inline(always)]
+    const fn to_bits(self) -> u64 {
+        self.left.id().to_bits() as u64 | ((self.right.id().to_bits() as u64) << 32)
     }
 }
 


### PR DESCRIPTION
Makes TokenPair be representable as a faux `u64` type, with optimised codegen to make use of the fact that it can basically be thrown around, compared and hashed as a `u64` value instead of two separate `u32` values. This should improve some throughput metrics for constructing the markov chains and during generation, but these are expected to be relatively small.