### PR TITLE
OTel Configuration

### DIFF
--- a/configuration/pit.default.toml
+++ b/configuration/pit.default.toml
@@ -18,3 +18,9 @@ chunk_size = 4096
 type = "soft_limit"
 soft_limit = 200
 soft_delay = 600
+
+[open_telemetry]
+endpoint = "http://127.0.0.1:4317"
+service_name = "nailpit"
+logs = false
+traces = false

--- a/nailconfig/src/lib.rs
+++ b/nailconfig/src/lib.rs
@@ -5,7 +5,8 @@
 
 use color_eyre::Result;
 use serde_aux::field_attributes::{
-    deserialize_number_from_string, deserialize_option_number_from_string,
+    deserialize_bool_from_anything, deserialize_number_from_string,
+    deserialize_option_number_from_string,
 };
 
 #[derive(Debug, serde::Deserialize)]
@@ -17,6 +18,7 @@ pub struct NailConfig {
     pub generator: GeneratorConfig,
     #[serde(default)]
     pub rate_limiting: RateLimitingConfig,
+    pub open_telemetry: OpenTelemetryConfig,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -69,6 +71,16 @@ pub enum RateLimitingConfig {
         #[serde(deserialize_with = "deserialize_number_from_string")]
         soft_delay: u64,
     },
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct OpenTelemetryConfig {
+    pub endpoint: String,
+    pub service_name: String,
+    #[serde(deserialize_with = "deserialize_bool_from_anything")]
+    pub logs: bool,
+    #[serde(deserialize_with = "deserialize_bool_from_anything")]
+    pub traces: bool,
 }
 
 pub fn get_configuration() -> Result<NailConfig> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,13 +39,13 @@ async fn nailpit_main(
             d.filter(EnvFilter::from_default_env())
                 .diagnostic(logforth::diagnostic::FastraceDiagnostic::default())
                 .append(logforth::append::FastraceEvent::default())
-                .append(nailpit::otel::init_logging_reporter())
+                .append(nailpit::otel::init_logging_reporter(config.as_ref()))
                 .append(append::Stderr::default())
         })
         .apply();
 
     #[cfg(feature = "tracing")]
-    nailpit::otel::init_tracing_reporter();
+    nailpit::otel::init_tracing_reporter(config.as_ref());
 
     log::info!("Welcome to Nailpit!");
     log::info!("Loaded config: {config:?}");

--- a/src/otel.rs
+++ b/src/otel.rs
@@ -1,43 +1,46 @@
 use fastrace::collector::Config;
 use fastrace_opentelemetry::OpenTelemetryReporter;
 use logforth::append::opentelemetry::OpentelemetryLogBuilder;
+use nailconfig::NailConfig;
 use opentelemetry::{InstrumentationScope, trace::SpanKind};
 use opentelemetry_otlp::{LogExporter, Protocol, SpanExporter, WithExportConfig, WithTonicConfig};
 use opentelemetry_sdk::Resource;
-use std::{borrow::Cow, time::Duration};
+use std::borrow::Cow;
 
-pub fn init_logging_reporter() -> logforth::append::OpentelemetryLog {
+pub fn init_logging_reporter(config: &NailConfig) -> logforth::append::OpentelemetryLog {
     let log_exporter = LogExporter::builder()
         .with_http()
-        .with_endpoint("http://localhost:4317")
+        .with_endpoint(&config.open_telemetry.endpoint)
         .build()
         .unwrap();
 
-    let builder = OpentelemetryLogBuilder::new("nailpit", log_exporter);
+    let builder =
+        OpentelemetryLogBuilder::new(config.open_telemetry.service_name.to_owned(), log_exporter);
 
     builder.build().unwrap()
 }
 
-pub fn init_tracing_reporter() {
+pub fn init_tracing_reporter(config: &NailConfig) {
     // Initialize reporter
     let reporter = OpenTelemetryReporter::new(
         SpanExporter::builder()
             .with_tonic()
-            .with_endpoint("http://127.0.0.1:4317")
+            .with_endpoint(&config.open_telemetry.endpoint)
             .with_protocol(Protocol::Grpc)
             .with_timeout(opentelemetry_otlp::OTEL_EXPORTER_OTLP_TIMEOUT_DEFAULT)
             .with_compression(opentelemetry_otlp::Compression::Zstd)
             .build()
             .expect("initialize oltp exporter"),
         SpanKind::Server,
-        Cow::Owned(Resource::builder().with_service_name("nailpit").build()),
-        InstrumentationScope::builder("nailpit")
+        Cow::Owned(
+            Resource::builder()
+                .with_service_name(config.open_telemetry.service_name.to_owned())
+                .build(),
+        ),
+        InstrumentationScope::builder(config.open_telemetry.service_name.to_owned())
             .with_version(env!("CARGO_PKG_VERSION"))
             .build(),
     );
 
-    fastrace::set_reporter(
-        reporter,
-        Config::default().report_interval(Duration::from_millis(100)),
-    );
+    fastrace::set_reporter(reporter, Config::default());
 }


### PR DESCRIPTION
Adds in configurability of Otel setup, mostly to be able to configure the gRPC endpoint to send your log/tracing data to. Will expand to metrics as well, but mostly this is a simple setup.

## TODO

- [x] Basic endpoint/service name configuration
- [ ] Toggle logs/traces
- [ ] Add in Metrics configuration