### PR TITLE
Poison Prompts in page generation

### DIFF
--- a/crates/nailconfig/src/lib.rs
+++ b/crates/nailconfig/src/lib.rs
@@ -3,6 +3,8 @@
 //! from either `toml` files or environment variables, with the format
 //! `PIT__GENERATOR__TIMEOUT` as an example.
 
+use std::ops::Deref;
+
 use color_eyre::Result;
 use serde_aux::field_attributes::{
     deserialize_bool_from_anything, deserialize_number_from_string,
@@ -21,8 +23,27 @@ pub struct NailConfig {
     pub open_telemetry: OpenTelemetryConfig,
 }
 
+#[derive(Default, serde::Deserialize)]
+pub struct PromptsList(Vec<String>);
+
+impl std::fmt::Debug for PromptsList {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("PromptsList").finish_non_exhaustive()
+    }
+}
+
+impl Deref for PromptsList {
+    type Target = [String];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 #[derive(Debug, serde::Deserialize)]
 pub struct GeneratorConfig {
+    #[serde(default)]
+    pub prompts: PromptsList,
     pub input_files: String,
     #[serde(deserialize_with = "deserialize_number_from_string")]
     pub min_paragraph_size: usize,

--- a/crates/nailgen/src/html_gen.rs
+++ b/crates/nailgen/src/html_gen.rs
@@ -3,7 +3,7 @@ use std::iter::once;
 use bytes::{Bytes, BytesMut};
 use nailconfig::NailConfig;
 use nailkov::{NailKov, interner::Interner};
-use rand::{Rng, RngCore, distr::Alphanumeric};
+use rand::{Rng, RngCore, distr::Alphanumeric, seq::IndexedRandom};
 use std::iter::repeat_with;
 
 use crate::INTERNER;
@@ -107,9 +107,20 @@ pub fn links(route: &str, max_links: usize, rng: &mut impl RngCore) -> Bytes {
     Bytes::from(nav)
 }
 
-pub fn footer(route: &str, max_links: usize, rng: &mut impl RngCore) -> Bytes {
-    let mut footer = BytesMut::from("</article></main>\n<footer>");
+pub fn footer(route: &str, prompts: &[String], max_links: usize, rng: &mut impl RngCore) -> Bytes {
+    let mut footer = BytesMut::new();
 
+    if let Some(prompt) = match prompts.len() {
+        0 => None,
+        1 => prompts.get(1),
+        _ => prompts.choose(rng),
+    } {
+        footer.extend(b"<p>");
+        footer.extend(prompt.as_bytes());
+        footer.extend(b"</p>");
+    }
+
+    footer.extend(b"</article></main>\n<footer>");
     footer.extend(links(route, max_links, rng));
     footer.extend(b"</footer>\n</body>\n</html>");
 

--- a/crates/nailgen/src/lib.rs
+++ b/crates/nailgen/src/lib.rs
@@ -150,7 +150,12 @@ impl MarkovGen {
             }
         }
 
-        let final_str = footer(path.as_str(), config.generator.max_pit_links, &mut rng);
+        let final_str = footer(
+            path.as_str(),
+            &config.generator.prompts,
+            config.generator.max_pit_links,
+            &mut rng,
+        );
 
         tx.send(final_str).await.ok();
     }

--- a/crates/nailotel/src/lib.rs
+++ b/crates/nailotel/src/lib.rs
@@ -17,7 +17,12 @@ pub fn init_logging_reporter(config: &NailConfig) -> logforth::append::Opentelem
     let builder =
         OpentelemetryLogBuilder::new(config.open_telemetry.service_name.to_owned(), log_exporter);
 
-    builder.build()
+    builder
+        .label(
+            "service.name",
+            config.open_telemetry.service_name.to_owned(),
+        )
+        .build()
 }
 
 pub fn init_tracing_reporter(config: &NailConfig) {


### PR DESCRIPTION
Adds the ability to include prompts at the end of a generated page in order to poison the data further. Add as many prompt strings in the configuration, and each page will randomly select one to append in the footer. The list of prompts is also hidden from the logging output so that it won't spam your terminal/logging infra with the text.