### PR TITLE
Simplify config, optimise gen loop for less allocations, use Rapidhash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,6 +624,9 @@ name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "equivalent",
+]
 
 [[package]]
 name = "hex"
@@ -1106,7 +1109,6 @@ dependencies = [
  "color-eyre",
  "config",
  "serde",
- "serde-aux",
 ]
 
 [[package]]
@@ -1157,11 +1159,13 @@ dependencies = [
 name = "nailkov"
 version = "0.1.0"
 dependencies = [
+ "hashbrown",
  "indexmap",
  "itertools",
  "log",
  "rand",
  "rand_distr",
+ "rapidhash",
  "unicode-segmentation",
  "wyrand",
 ]
@@ -1412,15 +1416,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-float"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1659,6 +1654,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rapidhash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "164772177ee16e3b074e6019c63cd92cb3cecf38e8c40d097675958b86dd8084"
+dependencies = [
+ "rand",
+ "rustversion",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1803,27 +1808,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde-aux"
-version = "4.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "207f67b28fe90fb596503a9bf0bf1ea5e831e21307658e177c5dfcdfc3ab8a0a"
-dependencies = [
- "serde",
- "serde-value",
- "serde_json",
-]
-
-[[package]]
-name = "serde-value"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
-dependencies = [
- "ordered-float",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 repository = "https://github.com/Bluefinger/nailpit"
 version = "0.1.0"
 license = "AGPL-3.0-only"
-rust-version = "1.86.0"
+rust-version = "1.89.0"
 
 [workspace.lints.clippy]
 undocumented_unsafe_blocks = "warn"
@@ -29,11 +29,12 @@ serde = { version = "1.0.219", features = ["derive"] }
 rand_core = "0.9.3"
 rand = { version = "0.9", default-features = false }
 rand_distr = { version = "0.5.1" }
-wyrand = { version = "0.3.2", features = ["wyhash", "fully_randomised_wyhash"] }
+wyrand = { version = "0.3.2" }
 hashbrown = { version = "0.15.2", default-features = false, features = [
     "equivalent",
     "inline-more",
 ] }
+rapidhash = { version = "4.1.0", default-features = false }
 fastrace = { version = "0.7.9" }
 fastrace-futures = { version = "0.7.9" }
 logforth = { version = "0.26", features = [
@@ -119,5 +120,5 @@ mimalloc-safe = { version = "0.1.50", optional = true }
 [profile.release]
 codegen-units = 1
 lto = "fat"
-strip = true
+debug = true
 panic = "abort"

--- a/configuration/pit.default.toml
+++ b/configuration/pit.default.toml
@@ -1,3 +1,4 @@
+[server]
 pit_routes = ["/private"]
 socket_addr = "0.0.0.0:3000"
 worker_threads = 4

--- a/crates/nailconfig/Cargo.toml
+++ b/crates/nailconfig/Cargo.toml
@@ -12,6 +12,5 @@ workspace = true
 
 [dependencies]
 serde.workspace = true
-serde-aux = { version = "4.5.0", default-features = false }
 config = { version = "0.15.11", default-features = false, features = ["toml"] }
 color-eyre.workspace = true

--- a/crates/nailconfig/src/lib.rs
+++ b/crates/nailconfig/src/lib.rs
@@ -1,22 +1,14 @@
 //! Crate for defining and handling `nailpit` configuration. Defines the main
 //! [`NailConfig`] struct, as well as the utility method to derive the config object
-//! from either `toml` files or environment variables, with the format
-//! `PIT__GENERATOR__TIMEOUT` as an example.
+//! from various `toml` files.
 
 use std::ops::Deref;
 
 use color_eyre::Result;
-use serde_aux::field_attributes::{
-    deserialize_bool_from_anything, deserialize_number_from_string,
-    deserialize_option_number_from_string,
-};
 
 #[derive(Debug, serde::Deserialize)]
 pub struct NailConfig {
-    pub pit_routes: Vec<String>,
-    pub socket_addr: String,
-    #[serde(deserialize_with = "deserialize_number_from_string")]
-    pub worker_threads: usize,
+    pub server: ServerConfig,
     pub generator: GeneratorConfig,
     #[serde(default)]
     pub rate_limiting: RateLimitingConfig,
@@ -41,27 +33,25 @@ impl Deref for PromptsList {
 }
 
 #[derive(Debug, serde::Deserialize)]
+pub struct ServerConfig {
+    pub pit_routes: Vec<String>,
+    pub socket_addr: String,
+    pub worker_threads: usize,
+}
+
+#[derive(Debug, serde::Deserialize)]
 pub struct GeneratorConfig {
     #[serde(default)]
     pub prompts: PromptsList,
     pub input_files: String,
-    #[serde(deserialize_with = "deserialize_number_from_string")]
     pub min_paragraph_size: usize,
-    #[serde(deserialize_with = "deserialize_option_number_from_string")]
     pub max_paragraph_size: Option<usize>,
-    #[serde(deserialize_with = "deserialize_number_from_string")]
     pub payload_size: usize,
-    #[serde(deserialize_with = "deserialize_number_from_string")]
     pub timeout: u64,
-    #[serde(deserialize_with = "deserialize_number_from_string")]
     pub min_delay: u64,
-    #[serde(deserialize_with = "deserialize_option_number_from_string")]
     pub max_delay: Option<u64>,
-    #[serde(deserialize_with = "deserialize_number_from_string")]
     pub chunk_size: usize,
-    #[serde(deserialize_with = "deserialize_number_from_string")]
     pub header_size: usize,
-    #[serde(deserialize_with = "deserialize_number_from_string")]
     pub max_pit_links: usize,
 }
 
@@ -88,28 +78,17 @@ pub enum RateLimitingConfig {
     #[serde(rename = "no_limit")]
     NoLimit,
     #[serde(rename = "soft_limit")]
-    SoftLimit {
-        #[serde(deserialize_with = "deserialize_number_from_string")]
-        soft_limit: u64,
-        #[serde(deserialize_with = "deserialize_number_from_string")]
-        soft_delay: u64,
-    },
+    SoftLimit { soft_limit: u64, soft_delay: u64 },
     #[serde(rename = "hard_limit")]
     HardLimit {
-        #[serde(deserialize_with = "deserialize_number_from_string")]
         hard_limit: u64,
-        #[serde(default)]
         drop_behavior: DropBehavior,
     },
     #[serde(rename = "soft_with_hard_limit")]
     SoftWithHardLimit {
-        #[serde(deserialize_with = "deserialize_number_from_string")]
         soft_limit: u64,
-        #[serde(deserialize_with = "deserialize_number_from_string")]
         hard_limit: u64,
-        #[serde(deserialize_with = "deserialize_number_from_string")]
         soft_delay: u64,
-        #[serde(default)]
         drop_behavior: DropBehavior,
     },
 }
@@ -118,9 +97,7 @@ pub enum RateLimitingConfig {
 pub struct OpenTelemetryConfig {
     pub endpoint: String,
     pub service_name: String,
-    #[serde(deserialize_with = "deserialize_bool_from_anything")]
     pub logs: bool,
-    #[serde(deserialize_with = "deserialize_bool_from_anything")]
     pub traces: bool,
 }
 
@@ -136,11 +113,6 @@ pub fn get_configuration() -> Result<NailConfig> {
             config::File::from(config_dir.join("pit.toml"))
                 .required(false)
                 .format(config::FileFormat::Toml),
-        )
-        .add_source(
-            config::Environment::with_prefix("PIT")
-                .prefix_separator("__")
-                .separator("__"),
         )
         .build()?;
 

--- a/crates/nailgen/src/html_gen.rs
+++ b/crates/nailgen/src/html_gen.rs
@@ -39,8 +39,6 @@ pub fn title(chain: &NailKov, config: &NailConfig, rng: &mut impl RngCore) -> (B
 
     let title_text: String = text_generator(&interner, chain, 24, rng).collect();
 
-    drop(interner);
-
     let mut title = BytesMut::new();
 
     title.extend(b"<title>");
@@ -58,28 +56,39 @@ pub fn title(chain: &NailKov, config: &NailConfig, rng: &mut impl RngCore) -> (B
     let max_paras: u32 = rng.random_range(1..=3);
 
     for _ in 0..max_paras {
-        header.extend(paragraph(chain, get_desired_size(config, rng), rng));
+        header.extend(paragraph(
+            &interner,
+            chain,
+            get_desired_size(config, rng),
+            rng,
+        ));
     }
 
     (title.freeze(), header.freeze())
 }
 
-pub fn paragraph(chain: &NailKov, size: usize, rng: &mut impl RngCore) -> Bytes {
-    let interner = INTERNER.read();
-
-    iter_into_bytes(
+pub fn paragraph<'a>(
+    interner: &'a Interner,
+    chain: &'a NailKov,
+    size: usize,
+    rng: &'a mut impl RngCore,
+) -> impl Iterator<Item = u8> + 'a {
+    into_bytes_iter(
         once("<p>")
-            .chain(text_generator(&interner, chain, size, rng))
+            .chain(text_generator(interner, chain, size, rng))
             .chain(once("</p>\n")),
     )
 }
 
-pub fn header(chain: &NailKov, size: usize, rng: &mut impl RngCore) -> Bytes {
-    let interner = INTERNER.read();
-
-    iter_into_bytes(
+pub fn header<'a>(
+    interner: &'a Interner,
+    chain: &'a NailKov,
+    size: usize,
+    rng: &'a mut impl RngCore,
+) -> impl Iterator<Item = u8> + 'a {
+    into_bytes_iter(
         once("\n<h2>")
-            .chain(text_generator(&interner, chain, size, rng))
+            .chain(text_generator(interner, chain, size, rng))
             .chain(once("</h2>\n")),
     )
 }
@@ -128,6 +137,6 @@ pub fn footer(route: &str, prompts: &[String], max_links: usize, rng: &mut impl 
 }
 
 #[inline]
-fn iter_into_bytes<'a>(generator: impl Iterator<Item = &'a str>) -> Bytes {
-    Bytes::from_iter(generator.flat_map(|text| text.as_bytes()).copied())
+fn into_bytes_iter<'a>(generator: impl Iterator<Item = &'a str>) -> impl Iterator<Item = u8> {
+    generator.flat_map(|text| text.as_bytes()).copied()
 }

--- a/crates/nailgen/src/lib.rs
+++ b/crates/nailgen/src/lib.rs
@@ -26,7 +26,7 @@ mod html_gen;
 
 static INTERNER: LazyLock<Arc<RwLock<Interner>>> = LazyLock::new(Default::default);
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct MarkovGen {
     chain: Arc<NailKov>,
 }
@@ -49,14 +49,21 @@ impl MarkovGen {
         // Allocate more than we need, as we might generate more tokens than our 4kB threshold
         let mut buffer = BytesMut::with_capacity(config.generator.chunk_size * 2);
 
+        let interner = INTERNER.read();
+
         loop {
             // Randomise how many paragraphs we want per section
             let max_paras: u32 = rng.random_range(1..=4);
 
-            buffer.extend(header(chain, config.generator.header_size, rng));
+            buffer.extend(header(&interner, chain, config.generator.header_size, rng));
 
             for _ in 0..max_paras {
-                buffer.extend(paragraph(chain, get_desired_size(config, rng), rng));
+                buffer.extend(paragraph(
+                    &interner,
+                    chain,
+                    get_desired_size(config, rng),
+                    rng,
+                ));
             }
 
             // We can generate more before handing it off to be streamed to the client,

--- a/crates/nailkov/Cargo.toml
+++ b/crates/nailkov/Cargo.toml
@@ -11,6 +11,8 @@ license.workspace = true
 workspace = true
 
 [dependencies]
+rapidhash = { workspace = true, features = ["rand", "unsafe"] }
+hashbrown.workspace = true
 rand.workspace = true
 rand_distr.workspace = true
 wyrand.workspace = true

--- a/crates/nailkov/src/distribution.rs
+++ b/crates/nailkov/src/distribution.rs
@@ -5,7 +5,7 @@ use core::hash::BuildHasher;
 use indexmap::IndexMap;
 use rand::Rng;
 use rand_distr::{Distribution, weighted::WeightedAliasIndex};
-use wyrand::RandomWyHashState;
+use rapidhash::fast::RandomState;
 
 use crate::{error::NailError, token::Token};
 
@@ -28,7 +28,7 @@ impl Distribution<Token> for TokenWeights {
 
 /// Builder for [`TokenWeights`].
 #[derive(Clone, Debug)]
-pub struct TokenWeightsBuilder<S = RandomWyHashState> {
+pub struct TokenWeightsBuilder<S = RandomState> {
     /// Counts how many times a token is likely to appear.
     occurrences: IndexMap<Token, u64, S>,
 }
@@ -63,8 +63,8 @@ impl<S: BuildHasher> TokenWeightsBuilder<S> {
     }
 }
 
-impl Default for TokenWeightsBuilder<RandomWyHashState> {
+impl Default for TokenWeightsBuilder<RandomState> {
     fn default() -> Self {
-        Self::new(RandomWyHashState::new())
+        Self::new(RandomState::new())
     }
 }

--- a/crates/nailkov/src/lib.rs
+++ b/crates/nailkov/src/lib.rs
@@ -7,30 +7,30 @@ pub mod interner;
 mod token;
 
 use error::NailError;
+use hashbrown::HashMap;
 use indexmap::IndexMap;
 use interner::Interner;
 use itertools::Itertools;
 use rand::{RngCore, seq::IteratorRandom};
 use rand_distr::Distribution;
-use std::hash::BuildHasher;
 
 use distribution::{TokenWeights, TokenWeightsBuilder};
+use rapidhash::fast::RandomState;
 use token::{Token, TokenPair};
 use unicode_segmentation::UnicodeSegmentation;
-use wyrand::RandomWyHashState;
 
 #[derive(Clone, Debug)]
-pub struct NailKov<S = RandomWyHashState> {
-    chain: IndexMap<TokenPair, TokenWeights, S>,
+pub struct NailKov {
+    chain: HashMap<TokenPair, TokenWeights, RandomState>,
 }
 
-pub struct NailKovIter<'a, R: RngCore, S = RandomWyHashState> {
+pub struct NailKovIter<'a, R: RngCore> {
     rng: &'a mut R,
-    chain: &'a NailKov<S>,
+    chain: &'a NailKov,
     prev: TokenPair,
 }
 
-impl<R: RngCore, S: BuildHasher> Iterator for NailKovIter<'_, R, S> {
+impl<R: RngCore> Iterator for NailKovIter<'_, R> {
     type Item = Token;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -42,7 +42,7 @@ impl<R: RngCore, S: BuildHasher> Iterator for NailKovIter<'_, R, S> {
     }
 }
 
-impl<S: BuildHasher> NailKov<S> {
+impl NailKov {
     fn generate_next_token(&self, rng: &mut impl RngCore, prev: TokenPair) -> Option<Token> {
         self.chain.get(&prev).map(|dist| dist.sample(rng))
     }
@@ -70,44 +70,43 @@ impl<S: BuildHasher> NailKov<S> {
     }
 }
 
-impl NailKov<RandomWyHashState> {
+impl NailKov {
     pub fn from_input(interner: &mut Interner, input: &str) -> Result<NailKov, NailError> {
-        NailBuilder::new(RandomWyHashState::new()).with_input(interner, input)
+        NailBuilder::new(RandomState::new()).with_input(interner, input)
     }
 }
 
-impl<S: BuildHasher + Clone + Default> NailKov<S> {
+impl NailKov {
     pub fn from_input_with_hasher(
         interner: &mut Interner,
         input: &str,
-        hasher: S,
-    ) -> Result<NailKov<S>, NailError> {
+        hasher: RandomState,
+    ) -> Result<NailKov, NailError> {
         NailBuilder::new(hasher).with_input(interner, input)
     }
 }
 
-#[derive(Debug)]
-struct NailBuilder<S = RandomWyHashState> {
-    chain: IndexMap<TokenPair, TokenWeightsBuilder<S>, S>,
+struct NailBuilder {
+    chain: IndexMap<TokenPair, TokenWeightsBuilder<RandomState>, RandomState>,
 }
 
-impl<S: BuildHasher + Clone + Default> NailBuilder<S> {
-    fn new(hasher: S) -> Self {
+impl NailBuilder {
+    fn new(hasher: RandomState) -> Self {
         Self {
             chain: IndexMap::with_hasher(hasher),
         }
     }
 
-    fn with_input(self, interned: &mut Interner, input: &str) -> Result<NailKov<S>, NailError> {
+    fn with_input(self, interned: &mut Interner, input: &str) -> Result<NailKov, NailError> {
         self.feed_str(interned, input)?.build()
     }
 
-    fn build(self) -> Result<NailKov<S>, NailError> {
+    fn build(self) -> Result<NailKov, NailError> {
         if self.chain.is_empty() {
             return Err(NailError::EmptyInput);
         }
 
-        let chain: IndexMap<TokenPair, TokenWeights, S> = self
+        let chain: HashMap<TokenPair, TokenWeights, RandomState> = self
             .chain
             .into_iter()
             .flat_map(|(pair, dist)| {
@@ -131,7 +130,7 @@ impl<S: BuildHasher + Clone + Default> NailBuilder<S> {
                 builder.add(next.into());
             }
             None => {
-                let mut builder = TokenWeightsBuilder::new(self.chain.hasher().clone());
+                let mut builder = TokenWeightsBuilder::new(*self.chain.hasher());
                 builder.add(next.into());
                 self.chain.insert(prev, builder);
             }

--- a/crates/nailroutes/src/lib.rs
+++ b/crates/nailroutes/src/lib.rs
@@ -71,6 +71,7 @@ pub fn nail_route(state: ServerState) -> Router {
 
     let pit = state
         .config
+        .server
         .pit_routes
         .iter()
         .fold(Router::new(), |router, path| {

--- a/crates/nailstate/src/lib.rs
+++ b/crates/nailstate/src/lib.rs
@@ -7,7 +7,7 @@ use nailrng::FastRng;
 use rand::seq::IndexedRandom;
 
 /// Smart pointer for all available Markov chains.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct NailInputs(Arc<[MarkovGen]>);
 
 impl NailInputs {
@@ -23,6 +23,12 @@ impl NailInputs {
 
             self.0.choose(&mut rng).unwrap().clone()
         }
+    }
+}
+
+impl std::fmt::Debug for NailInputs {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("NailInputs").finish_non_exhaustive()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ async fn spawn_axum_server<F>(
 where
     F: Future<Output = ()> + Send + 'static,
 {
-    let listener = tokio::net::TcpListener::bind(&state.config.socket_addr).await?;
+    let listener = tokio::net::TcpListener::bind(&state.config.server.socket_addr).await?;
 
     log::info!("listening on http://{}", listener.local_addr()?,);
 
@@ -94,7 +94,7 @@ fn main() -> Result<()> {
         .worker_threads(
             std::thread::available_parallelism()?
                 .get()
-                .min(config.worker_threads),
+                .min(config.server.worker_threads),
         )
         .enable_all()
         .build()?;


### PR DESCRIPTION
Updates nailpit to remove all the crap for env handling, just deferring to toml files for the configuration. Also adds some optimisations to improve throughput by reducing allocations in the generation hot loop, and by switching to Rapidhash which should be faster. Indexmap also has slightly more overhead in the lookup part, so just using Hashmap directly so to improve interning lookups slightly.