### PR TITLE
fix: Gen state machine fixes, runtime improvements

### DIFF
--- a/crates/nailgen/src/html_gen.rs
+++ b/crates/nailgen/src/html_gen.rs
@@ -1,5 +1,3 @@
-use std::iter::once;
-
 use bytes::{Bytes, BytesMut};
 use nailconfig::NailConfig;
 use nailkov::{NailKov, interner::Interner};
@@ -26,11 +24,13 @@ fn text_generator<'a>(
     chain: &'a NailKov,
     size: usize,
     rng: &'a mut impl RngCore,
-) -> impl Iterator<Item = &'a [u8]> + 'a {
+) -> impl Iterator<Item = &'a u8> + 'a {
     chain
         .generate_tokens(rng)
         .take(size)
-        .flat_map(|token| interner.lookup_bytes(token))
+        .filter_map(|token| interner.lookup_bytes(token))
+        .flatten()
+        .skip_while(|&text| !text.is_ascii_alphabetic())
 }
 
 #[fastrace::trace]
@@ -50,13 +50,10 @@ pub fn initial_content(
         .as_bytes(),
     );
 
-    let title_text: Vec<u8> = text_generator(&interner, chain, 24, rng)
-        .flatten()
-        .copied()
-        .collect();
+    let title_text: Vec<u8> = text_generator(&interner, chain, 24, rng).copied().collect();
 
     buf_mut.extend_from_slice(b"<title>");
-    buf_mut.extend_from_slice(&title_text);
+    buf_mut.extend_from_slice(title_text.as_slice());
     buf_mut.extend_from_slice(b"</title>\n");
 
     buf_mut.extend_from_slice(
@@ -131,10 +128,15 @@ pub fn footer(chain: &NailKov, route: &str, config: &NailConfig, rng: &mut impl 
         footer.extend_from_slice(b"</p>");
     }
 
-    let interner = INTERNER.read();
-
     footer.extend_from_slice(b"</article></main>\n<footer>");
-    links(&interner, chain, route, config.generator.max_pit_links, rng, &mut footer);
+    links(
+        &INTERNER.read(),
+        chain,
+        route,
+        config.generator.max_pit_links,
+        rng,
+        &mut footer,
+    );
     footer.extend_from_slice(b"</footer>\n</body>\n</html>");
 
     footer.freeze()
@@ -146,10 +148,10 @@ fn paragraph<'a>(
     size: usize,
     rng: &'a mut impl RngCore,
 ) -> impl Iterator<Item = &'a u8> + 'a {
-    once(b"<p>".as_slice())
+    b"<p>"
+        .iter()
         .chain(text_generator(interner, chain, size, rng))
-        .chain(once(b"</p>\n".as_slice()))
-        .flatten()
+        .chain(b"</p>\n")
 }
 
 fn header<'a>(
@@ -158,10 +160,10 @@ fn header<'a>(
     size: usize,
     rng: &'a mut impl RngCore,
 ) -> impl Iterator<Item = &'a u8> + 'a {
-    once(b"\n<h2>".as_slice())
+    b"\n<h2>"
+        .iter()
         .chain(text_generator(interner, chain, size, rng))
-        .chain(once(b"</h2>\n".as_slice()))
-        .flatten()
+        .chain(b"</h2>\n")
 }
 
 fn links<'a>(
@@ -182,7 +184,7 @@ fn links<'a>(
         buf_mut.extend_from_slice(b"/");
         buf_mut.extend(rng.sample_iter(Alphanumeric).take(16));
         buf_mut.extend_from_slice(b"\">");
-        buf_mut.extend(text_generator(interner, chain, 8, rng).flatten());
+        buf_mut.extend(text_generator(interner, chain, 8, rng));
         buf_mut.extend_from_slice(b"</a></li>");
     }
 

--- a/crates/nailgen/src/lib.rs
+++ b/crates/nailgen/src/lib.rs
@@ -1,11 +1,11 @@
 //! Crate for defining a HTML generator based on a markov chain source, using a string
 //! interner to reduce memory usage both within a markov chain and across multiple chains.
 
-use core::{pin::Pin, task::Poll};
+use core::task::Poll;
 use std::{
     path::Path,
     sync::{Arc, LazyLock},
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use axum::extract::NestedPath;
@@ -27,19 +27,25 @@ use crate::{
 mod delay;
 mod html_gen;
 
-static INTERNER: LazyLock<Arc<RwLock<Interner>>> = LazyLock::new(Default::default);
+pub static INTERNER: LazyLock<Arc<RwLock<Interner>>> = LazyLock::new(Default::default);
 
 #[derive(Clone)]
 pub struct MarkovGen {
     chain: Arc<NailKov>,
 }
 
-enum GeneratorState {
-    Header,
-    MainContent,
-    Delay { delay: Pin<Box<Sleep>> },
-    Footer,
-    Finished,
+pin_project! {
+    #[project = GeneratorStateProj]
+    enum GeneratorState {
+        Header,
+        MainContent,
+        Delay {
+            #[pin]
+            delay: Sleep
+        },
+        Footer,
+        Finished,
+    }
 }
 
 pin_project! {
@@ -50,6 +56,7 @@ pin_project! {
         start_time: Instant,
         total_bytes: usize,
         rng: FastRng,
+        #[pin]
         state: GeneratorState,
     }
 }
@@ -73,42 +80,45 @@ impl Stream for MarkovStream {
 
     #[fastrace::trace]
     fn poll_next(
-        self: std::pin::Pin<&mut Self>,
+        mut self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Option<Self::Item>> {
-        let this = self.project();
+    ) -> Poll<Option<Self::Item>> {
+        let mut this = self.as_mut().project();
 
         loop {
-            match this.state {
-                GeneratorState::Header => {
+            match this.state.as_mut().project() {
+                GeneratorStateProj::Header => {
                     let mut content = BytesMut::with_capacity(2048);
 
                     initial_content(&this.markov.chain, this.config, this.rng, &mut content);
 
                     *this.total_bytes += content.len();
 
-                    *this.state = GeneratorState::MainContent;
+                    if let Some(delay) = delay_output(this.config, this.rng) {
+                        this.state.set(GeneratorState::Delay { delay });
+                    } else {
+                        this.state.set(GeneratorState::MainContent);
+                    }
 
                     return Poll::Ready(Some(content.freeze()));
                 }
-                GeneratorState::MainContent => {
-                    let time_limit = std::time::Duration::from_secs(this.config.generator.timeout);
+                GeneratorStateProj::MainContent => {
+                    let time_limit = Duration::from_secs(this.config.generator.timeout);
 
-                    if time_limit.as_secs() == 0 && this.start_time.elapsed() >= time_limit {
-                        *this.state = GeneratorState::Footer;
+                    if time_limit.as_secs() > 0
+                        && this.start_time.elapsed().as_secs() >= time_limit.as_secs()
+                    {
+                        this.state.set(GeneratorState::Footer);
                         continue;
                     }
 
                     if *this.total_bytes >= (this.config.generator.payload_size * 1024) {
-                        *this.state = GeneratorState::Footer;
+                        this.state.set(GeneratorState::Footer);
                         continue;
                     }
 
                     if let Some(delay) = delay_output(this.config, this.rng) {
-                        *this.state = GeneratorState::Delay {
-                            delay: Box::pin(delay),
-                        };
-                        continue;
+                        this.state.set(GeneratorState::Delay { delay });
                     }
 
                     let content = main_content(&this.markov.chain, this.config, this.rng);
@@ -117,14 +127,16 @@ impl Stream for MarkovStream {
 
                     return Poll::Ready(Some(content));
                 }
-                GeneratorState::Delay { delay } => {
-                    if delay.as_mut().poll(cx).is_pending() {
-                        return Poll::Pending;
+                GeneratorStateProj::Delay { delay } => {
+                    match delay.poll(cx) {
+                        Poll::Ready(_) => {
+                            this.state.set(GeneratorState::MainContent);
+                            continue;
+                        }
+                        Poll::Pending => return Poll::Pending,
                     }
-
-                    *this.state = GeneratorState::MainContent;
                 }
-                GeneratorState::Footer => {
+                GeneratorStateProj::Footer => {
                     let content = footer(
                         this.markov.chain.as_ref(),
                         this.path.as_str(),
@@ -134,7 +146,7 @@ impl Stream for MarkovStream {
 
                     *this.total_bytes += content.len();
 
-                    *this.state = GeneratorState::Finished;
+                    this.state.set(GeneratorState::Finished);
 
                     log::info!(
                         "Written ({:.2} MB in {}us)",
@@ -144,26 +156,23 @@ impl Stream for MarkovStream {
 
                     return Poll::Ready(Some(content));
                 }
-                GeneratorState::Finished => return Poll::Ready(None),
+                GeneratorStateProj::Finished => return Poll::Ready(None),
             }
         }
     }
 }
 
 impl MarkovGen {
-    pub fn new(input: impl AsRef<Path>) -> Result<Self> {
+    pub fn new(input: impl AsRef<Path>, interner: &mut Interner) -> Result<Self> {
         let file = std::fs::read_to_string(input.as_ref())?;
 
-        let mut interner_write_lock = INTERNER.write();
-
-        let chain = Arc::new(NailKov::from_input(&mut interner_write_lock, &file)?);
-
-        drop(interner_write_lock);
+        let chain = Arc::new(NailKov::from_input(interner, &file)?);
 
         Ok(Self { chain })
     }
 
     #[fastrace::trace]
+    #[inline]
     pub fn into_stream(self, path: NestedPath, config: Arc<NailConfig>) -> MarkovStream {
         MarkovStream::new(path, config, self)
     }

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -2,15 +2,17 @@ use std::sync::Arc;
 
 use glob::glob;
 use nailconfig::NailConfig;
-use nailgen::MarkovGen;
+use nailgen::{MarkovGen, INTERNER};
 
 /// Takes a glob for finding all input files and returns a read-only list of
 /// all markov chains that can be generated.
 pub fn get_input_files(config: &NailConfig) -> color_eyre::Result<Arc<[MarkovGen]>> {
+    let mut interner = INTERNER.write();
+
     let inputs = glob(&config.generator.input_files)?
         .filter_map(|path| path.inspect_err(|err| log::error!("IO Error: {err}")).ok())
         .filter_map(|input| {
-            MarkovGen::new(input)
+            MarkovGen::new(input, &mut interner)
                 .inspect_err(|err| log::error!("Markov Error: {err}"))
                 .ok()
         })

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,44 +8,24 @@ use nailpit::app::App;
 #[global_allocator]
 static GLOBAL: mimalloc_safe::MiMalloc = mimalloc_safe::MiMalloc;
 
-async fn spawn_axum_server<F>(
-    state: nailstate::ServerState,
-    spicy: Option<Arc<nailspicy::SpicyPayloads>>,
-    shutdown: F,
-) -> Result<()>
-where
-    F: Future<Output = ()> + Send + 'static,
-{
+async fn spawn_axum_worker(
+    app: App,
+    shutdown_notifier: Arc<tokio::sync::watch::Sender<()>>,
+) -> Result<()> {
+    let state = nailstate::ServerState::new(app.config, app.inputs);
     let listener = nailpit::net::get_tcp_socket(&state.config.server.socket_addr)?;
 
     log::info!("worker listening on http://{}", listener.local_addr()?);
 
-    tokio::spawn(
-        axum::serve(
-            listener,
-            nailroutes::nail_app(nailroutes::nail_route(state.clone()), state, spicy)
-                .into_make_service_with_connect_info::<SocketAddr>(),
-        )
-        .with_graceful_shutdown(shutdown)
-        .into_future(),
+    axum::serve(
+        listener,
+        nailroutes::nail_app(nailroutes::nail_route(state.clone()), state, app.spicy)
+            .into_make_service_with_connect_info::<SocketAddr>(),
     )
-    .await??;
+    .with_graceful_shutdown(nailpit::shutdown::wait_for_shutdown(shutdown_notifier))
+    .await?;
 
     Ok(())
-}
-
-async fn nailpit_worker_main(app: App, shutdown_notifier: Arc<tokio::sync::watch::Sender<()>>) {
-    let state = nailstate::ServerState::new(app.config, app.inputs);
-
-    if let Err(e) = spawn_axum_server(
-        state,
-        app.spicy,
-        nailpit::shutdown::wait_for_shutdown(shutdown_notifier),
-    )
-    .await
-    {
-        log::error!("Server failed with: {}", e);
-    }
 }
 
 fn main() -> Result<()> {
@@ -57,7 +37,7 @@ fn main() -> Result<()> {
 
     let spicy = nailspicy::get_spicy_payload(config.as_ref()).map(Arc::new);
 
-    nailpit::runtime::start(App::new(config, inputs, spicy), nailpit_worker_main)?;
+    nailpit::runtime::start(App::new(config, inputs, spicy), spawn_axum_worker)?;
 
     log::info!("Everything shutdown gracefully. Good night :)");
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -5,7 +5,7 @@ use crate::app::App;
 
 pub fn start<Fut, F>(app: App, main_fn: F) -> color_eyre::Result<()>
 where
-    Fut: Future<Output = color_eyre::Result<()>> + Send,
+    Fut: Future<Output = color_eyre::Result<()>>,
     F: Fn(App, Arc<tokio::sync::watch::Sender<()>>) -> Fut + Clone + Sync + Send,
 {
     let workers = std::thread::available_parallelism()?.min(app.config.server.worker_threads);

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,14 +1,12 @@
 use core::time::Duration;
 use std::sync::Arc;
 
-use futures_concurrency::future::Join;
-
 use crate::app::App;
 
-pub fn start<Fut, F>(app: App, main_fn: F) -> std::io::Result<()>
+pub fn start<Fut, F>(app: App, main_fn: F) -> color_eyre::Result<()>
 where
-    Fut: Future<Output = ()>,
-    F: Fn(App, Arc<tokio::sync::watch::Sender<()>>) -> Fut + Clone + Send + 'static,
+    Fut: Future<Output = color_eyre::Result<()>> + Send,
+    F: Fn(App, Arc<tokio::sync::watch::Sender<()>>) -> Fut + Clone + Sync + Send,
 {
     let workers = std::thread::available_parallelism()?.min(app.config.server.worker_threads);
 
@@ -21,44 +19,56 @@ where
         .enable_all()
         .build()?;
 
-    for num in 1..workers.get() {
-        let cloned = main_fn.clone();
-        let app = app.clone();
-        let shutdown_notifier = shutdown_notifier.clone();
+    std::thread::scope(|s| {
+        for num in 1..workers.get() {
+            let cloned = &main_fn;
+            let app = &app;
+            let shutdown_notifier = &shutdown_notifier;
 
-        // If any worker threads fail to be created, the program will terminate. If the
-        // runtime within the worker thread fails to be created, this won't terminate the
-        // program, but the error will get logged.
-        std::thread::Builder::new()
-            .name(format!("Nailpit worker {num}"))
-            .spawn(move || {
-                match tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                {
-                    Ok(rt) => {
-                        rt.block_on(cloned(app, shutdown_notifier));
+            // If any worker threads fail to be created, the program will terminate. If the
+            // runtime within the worker thread fails to be created, this won't terminate the
+            // program, but the error will get logged.
+            std::thread::Builder::new()
+                .name(format!("Nailpit worker {num}"))
+                .spawn_scoped(s, move || {
+                    match tokio::runtime::Builder::new_current_thread()
+                        .enable_all()
+                        .build()
+                    {
+                        Ok(rt) => {
+                            // If we hit an application error case, restart the worker
+                            while let Err(e) =
+                                rt.block_on(cloned(app.clone(), shutdown_notifier.clone()))
+                            {
+                                log::error!("Worker {num} failed with: {e}");
+                                // Wait a moment before trying again
+                                std::thread::sleep(Duration::from_secs(1));
+                                log::info!("Restarting Worker {num}...");
+                            }
 
-                        rt.shutdown_timeout(Duration::from_secs(60));
+                            rt.shutdown_timeout(Duration::from_secs(60));
+                        }
+                        Err(e) => log::error!("Worker {num} failed to start: {e}"),
                     }
-                    Err(e) => log::error!("Worker {} failed to start: {}", num, e),
-                }
-            })?;
-    }
+                })?;
+        }
 
-    rt.block_on(async move {
-        crate::telemetry::init_telemetry(app.config.clone());
+        rt.block_on(async {
+            crate::telemetry::init_telemetry(app.config.clone());
 
-        let app_fut = main_fn(app, shutdown_notifier);
+            let handle = tokio::spawn(crate::shutdown::shutdown_task(shutdown_signal));
 
-        let sig_watch = async move {
-            if let Err(e) = crate::shutdown::shutdown_task(shutdown_signal).await {
-                log::error!("SIG error: {}", e);
+            // If we hit an application error case, restart the worker.
+            while let Err(e) = main_fn(app.clone(), shutdown_notifier.clone()).await {
+                log::error!("Worker 0 failed with {e}");
+                // Wait a moment before trying again
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                log::info!("Restarting Worker 0...");
             }
-        };
 
-        (sig_watch, app_fut).join().await;
-    });
+            handle.await?
+        })
+    })?;
 
     log::info!("Waiting for background tasks to complete...");
 


### PR DESCRIPTION
Basically, refactor introduced some bugs, and this PR fixes them. The generator state machine wasn't working correctly for delayed output, and now there's some improvements on the output quality as well. The runtime is also tidied so it is clearer that the threads don't last for the entire program and do close when the program begins to terminate, allowing to avoid some cloning here and there.