### PR TITLE
refactor: Improved tracing and routing handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,7 +1126,6 @@ dependencies = [
 name = "nailgen"
 version = "0.1.0"
 dependencies = [
- "axum",
  "bytes",
  "color-eyre",
  "fastrace",
@@ -1304,6 +1303,8 @@ dependencies = [
  "fastrace",
  "hyper",
  "nailip",
+ "opentelemetry-semantic-conventions",
+ "pin-project-lite",
  "tower-http",
  "uuid",
 ]
@@ -1403,6 +1404,12 @@ dependencies = [
  "serde",
  "tonic",
 ]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d059a296a47436748557a353c5e6c5705b9470ef6c95cfc52c21a8814ddac2"
 
 [[package]]
 name = "opentelemetry_sdk"

--- a/crates/nailgen/Cargo.toml
+++ b/crates/nailgen/Cargo.toml
@@ -25,4 +25,3 @@ bytes.workspace = true
 log.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
-axum.workspace = true

--- a/crates/nailgen/src/lib.rs
+++ b/crates/nailgen/src/lib.rs
@@ -9,7 +9,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use axum::extract::NestedPath;
 use bytes::Bytes;
 use color_eyre::Result;
 use futures_lite::{FutureExt, Stream};
@@ -49,7 +48,7 @@ pin_project! {
 
 pin_project! {
     pub struct MarkovStream {
-        path: NestedPath,
+        path: Option<Box<str>>,
         config: Arc<NailConfig>,
         interner: Arc<Interner>,
         markov: MarkovGen,
@@ -63,7 +62,7 @@ pin_project! {
 impl MarkovStream {
     pub fn new(
         markov: MarkovGen,
-        path: NestedPath,
+        path: Option<Box<str>>,
         config: Arc<NailConfig>,
         interner: Arc<Interner>,
     ) -> Self {
@@ -158,7 +157,7 @@ impl Stream for MarkovStream {
                     let content = footer(
                         this.interner,
                         this.markov.chain.as_ref(),
-                        this.path.as_str(),
+                        this.path.as_deref().unwrap_or(""),
                         this.config,
                     );
 
@@ -193,7 +192,7 @@ impl MarkovGen {
     #[inline]
     pub fn into_stream(
         self,
-        path: NestedPath,
+        path: Option<Box<str>>,
         config: Arc<NailConfig>,
         interner: Arc<Interner>,
     ) -> MarkovStream {

--- a/crates/nailroutes/Cargo.toml
+++ b/crates/nailroutes/Cargo.toml
@@ -14,7 +14,7 @@ nailrater = { path = "../nailrater" }
 nailstate = { path = "../nailstate" }
 nailstream = { path = "../nailstream" }
 nailspicy = { path = "../nailspicy" }
-axum.workspace = true
+axum = { workspace = true, features = ["original-uri"] }
 hyper.workspace = true
 fastrace.workspace = true
 fastrace-futures.workspace = true

--- a/crates/nailroutes/src/lib.rs
+++ b/crates/nailroutes/src/lib.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use axum::{
     Router,
-    extract::NestedPath,
+    extract::OriginalUri,
     response::{Html, IntoResponse},
     routing::get,
 };
@@ -29,7 +29,13 @@ async fn index() -> Html<&'static str> {
 }
 
 #[fastrace::trace]
-async fn generated(config: AppConfig, inputs: NailInputs, path: NestedPath) -> impl IntoResponse {
+async fn generated(config: AppConfig, inputs: NailInputs, path: OriginalUri) -> impl IntoResponse {
+    let path: Option<Box<str>> = path
+        .0
+        .path()
+        .rsplit_once("/")
+        .map(|(prefix, _)| prefix.into());
+
     NailResponseStream::from_stream(
         inputs
             .get_random_input()
@@ -38,12 +44,10 @@ async fn generated(config: AppConfig, inputs: NailInputs, path: NestedPath) -> i
     )
 }
 
-pub fn nail_app(
-    routes: Router,
-    state: ServerState,
-    spicy_payload: Option<Arc<SpicyPayloads>>,
-) -> Router {
-    routes
+pub fn nail_app(state: ServerState, spicy_payload: Option<Arc<SpicyPayloads>>) -> Router {
+    let rate_limiting = state.config.rate_limiting.clone();
+
+    nail_route(state)
         .layer(
             ServiceBuilder::new()
                 .set_x_request_id(MakeRequestUuid)
@@ -51,10 +55,7 @@ pub fn nail_app(
                 .layer(axum::middleware::from_fn(tracing_root_span))
                 .layer(NormalizePathLayer::trim_trailing_slash())
                 .layer(CompressionLayer::new().quality(CompressionLevel::Default))
-                .layer(NailRaterLayer::new(
-                    state.config.rate_limiting.clone(),
-                    spicy_payload,
-                ))
+                .layer(NailRaterLayer::new(rate_limiting, spicy_payload))
                 .propagate_x_request_id(),
         )
         .route("/favicon.ico", get(async || StatusCode::NOT_FOUND))
@@ -62,17 +63,22 @@ pub fn nail_app(
 }
 
 pub fn nail_route(state: ServerState) -> Router {
-    let index = Router::new().route("/", get(index));
+    let generator_routes = Router::new()
+        .route("/", get(index))
+        .route("/{*generated}", get(generated));
 
-    let pit = state
+    state
         .config
         .server
         .pit_routes
         .iter()
-        .fold(Router::new(), |router, path| {
-            router.nest(path.as_str(), Router::new().fallback(get(generated)))
+        .fold(generator_routes, |router, path| {
+            if path == "/" {
+                router
+            } else {
+                let nested = router.clone();
+                router.nest(path.as_str(), nested)
+            }
         })
-        .with_state(state);
-
-    index.merge(pit)
+        .with_state(state)
 }

--- a/crates/nailtrace/Cargo.toml
+++ b/crates/nailtrace/Cargo.toml
@@ -9,10 +9,12 @@ rust-version.workspace = true
 
 [dependencies]
 nailip = { path = "../nailip" }
-axum.workspace = true
+axum = { workspace = true, features = ["matched-path"] }
 fastrace.workspace = true
 hyper.workspace = true
 tower-http.workspace = true
+pin-project-lite.workspace = true
+opentelemetry-semantic-conventions = "0.30"
 uuid = { version = "1.17.0", features = ["v4", "fast-rng"] }
 
 [lints]

--- a/crates/nailtrace/src/lib.rs
+++ b/crates/nailtrace/src/lib.rs
@@ -1,7 +1,16 @@
-use axum::{Extension, extract::Request, middleware::Next, response::Response};
+use axum::{
+    Extension,
+    extract::{MatchedPath, Request},
+    middleware::Next,
+    response::Response,
+};
 use fastrace::prelude::*;
-use hyper::header::USER_AGENT;
+use hyper::header::{CONTENT_ENCODING, CONTENT_TYPE, USER_AGENT};
 use nailip::IdentifiedPeer;
+use opentelemetry_semantic_conventions::trace::{
+    CLIENT_ADDRESS, HTTP_REQUEST_METHOD, HTTP_RESPONSE_STATUS_CODE, HTTP_ROUTE, URL_PATH,
+    USER_AGENT_ORIGINAL,
+};
 use tower_http::request_id::RequestId;
 
 /// The standard [W3C Trace Context](https://www.w3.org/TR/trace-context/) header name for passing trace information.
@@ -22,32 +31,98 @@ pub async fn tracing_root_span(
         .and_then(|traceparent| SpanContext::decode_w3c_traceparent(traceparent.to_str().ok()?))
         .unwrap_or_else(SpanContext::random);
 
-    let root_name = if request.uri() == "/" {
-        String::from("Index Page")
+    let path = if let Some(nested) = request.extensions().get::<MatchedPath>() {
+        nested.as_str().to_string()
     } else {
-        String::from("Generated Page")
+        String::from("/")
     };
 
-    let root = Span::root(root_name, parent).with_properties(|| {
+    let url_path = request.uri().path().to_string();
+
+    let root_name = format!("GET {path}");
+
+    let root = Span::root(root_name, parent);
+
+    root.add_properties(|| {
         [
+            (HTTP_ROUTE, path),
+            (HTTP_REQUEST_METHOD, request.method().to_string()),
+            (URL_PATH, url_path),
             (
-                "request.id",
+                "http.request.header.request_id",
                 request_id
                     .header_value()
                     .to_str()
                     .map_or_else(|_| uuid::Uuid::new_v4().to_string(), ToString::to_string),
             ),
-            ("request.uri", request.uri().to_string()),
             (
-                "user.agent",
+                USER_AGENT_ORIGINAL,
                 headers
                     .get(USER_AGENT)
                     .and_then(|header| header.to_str().ok())
                     .map_or_else(|| "None".to_string(), ToString::to_string),
             ),
-            ("user.ip", peer.to_string()),
+            (CLIENT_ADDRESS, peer.to_string()),
         ]
     });
 
-    next.run(request).in_span(root).await
+    let response = InspectHttpResponse {
+        inner: next.run(request),
+    };
+
+    response.in_span(root).await
+}
+
+pin_project_lite::pin_project! {
+    struct InspectHttpResponse<F> {
+        #[pin]
+        inner: F,
+    }
+}
+
+impl<F> core::future::Future for InspectHttpResponse<F>
+where
+    F: core::future::Future<Output = Response>,
+{
+    type Output = F::Output;
+
+    fn poll(
+        self: core::pin::Pin<&mut Self>,
+        cx: &mut core::task::Context<'_>,
+    ) -> core::task::Poll<Self::Output> {
+        let this = self.project();
+        let poll = this.inner.poll(cx);
+
+        if let core::task::Poll::Ready(response) = &poll {
+            let headers = response.headers();
+
+            if let Some((content_encoding, content_type)) = headers
+                .get(CONTENT_ENCODING)
+                .and_then(|header| header.to_str().ok())
+                .map(ToString::to_string)
+                .zip(
+                    headers
+                        .get(CONTENT_TYPE)
+                        .and_then(|header| header.to_str().ok())
+                        .map(ToString::to_string),
+                )
+            {
+                LocalSpan::add_properties(|| {
+                    [
+                        ("http.response.header.content_encoding", content_encoding),
+                        ("http.response.header.content_type", content_type),
+                    ]
+                });
+            }
+
+            LocalSpan::add_properties(|| {
+                [(
+                    HTTP_RESPONSE_STATUS_CODE,
+                    response.status().as_u16().to_string(),
+                )]
+            });
+        }
+
+        poll
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,8 +19,7 @@ async fn spawn_axum_worker(
 
     axum::serve(
         listener,
-        nailroutes::nail_app(nailroutes::nail_route(state.clone()), state, app.spicy)
-            .into_make_service_with_connect_info::<SocketAddr>(),
+        nailroutes::nail_app(state, app.spicy).into_make_service_with_connect_info::<SocketAddr>(),
     )
     .with_graceful_shutdown(nailpit::shutdown::wait_for_shutdown(shutdown_notifier))
     .await?;


### PR DESCRIPTION
This PR adds two refactors:

1) Better tracing output for OTEL, using more semantic conventions where possible, and now that it is in better shape to also have fields based on the response output, I can add more data later on more easily.

2) Better routing. Now the routing should handle not just nested routes so like "/private" or "/spicy", but also root level "/". This means the ground work for templating is in place, since the "static" index/warning page needs to generate entry links on which path the bot is entering in.