### PR TITLE
refactor: Async rate limiting

### DIFF
--- a/crates/nailotel/src/lib.rs
+++ b/crates/nailotel/src/lib.rs
@@ -35,12 +35,16 @@ pub struct OtelGuard {
 
 impl Drop for OtelGuard {
     fn drop(&mut self) {
-        self.otel_logger
-            .take()
-            .map(|logs_provider| logs_provider.shutdown());
-        self.otel_traces
-            .take()
-            .map(|trace_provider| trace_provider.shutdown());
+        if let Some(logs_provider) = self.otel_logger.take()
+            && let Err(e) = logs_provider.shutdown()
+        {
+            tracing::error!(error = %e, "Error shutting down Logs Provider");
+        }
+        if let Some(trace_provider) = self.otel_traces.take()
+            && let Err(e) = trace_provider.shutdown()
+        {
+            tracing::error!(error = %e, "Error shutting down Trace Provider");
+        }
     }
 }
 

--- a/crates/nailrater/src/futures.rs
+++ b/crates/nailrater/src/futures.rs
@@ -1,35 +1,50 @@
-use std::{
+use core::{
     pin::Pin,
     task::{Context, Poll},
 };
+use std::{sync::Arc, time::Instant};
 
 use axum::{
     body::{Body, Bytes},
+    extract::Request,
     http::HeaderValue,
     response::{IntoResponse, Response},
 };
-use futures_lite::{future::Boxed, ready};
+use futures_lite::{FutureExt, future::Boxed, ready};
 use hyper::{
     StatusCode,
     header::{CONTENT_ENCODING, CONTENT_TYPE},
 };
-use nailspicy::SpicyPayloadKind;
+use nailbox::boxed_future_within;
+use nailip::IdentifiedPeer;
+use nailspicy::{SpicyPayloadKind, SpicyPayloads};
 use pin_project_lite::pin_project;
-use tokio::time::Sleep;
+use rapidhash::quality::RandomState;
+use scc::hash_map::Entry;
+use tokio::time::{Sleep, sleep};
+
+use crate::{PEERS, PeerRecord, PeerState, modes::LimitModes, scheduler::PRUNING_SCHEDULER};
 
 pin_project! {
-    pub struct NailedResponseFuture<T> {
+    pub struct NailedResponseFuture<S, F> {
         #[pin]
-        state: NailedState<T>,
+        state: NailedState<S, F>,
     }
 }
 
 pin_project! {
     #[project = NailedStateProj]
-    enum NailedState<T> {
+    enum NailedState<S, F> {
+        RatePeer {
+            req: Option<Request>,
+            spicy_payloads: Option<Arc<SpicyPayloads>>,
+            mode: LimitModes,
+            entry: Boxed<Entry<'static, IdentifiedPeer, PeerRecord, RandomState>>,
+            inner: S,
+        },
         Normal {
             #[pin]
-            state: NailedNormalFuture<T>,
+            state: NailedNormalFuture<F>,
         },
         Other {
             state: NailedOtherState,
@@ -60,6 +75,17 @@ pin_project! {
     }
 }
 
+impl NormalState {
+    #[inline]
+    fn new(prune: Option<Boxed<()>>, delay: Option<Pin<Box<Sleep>>>) -> Self {
+        match (prune, delay) {
+            (Some(prune), delay) => NormalState::Prune { prune, delay },
+            (None, Some(delay)) => NormalState::Delay { delay },
+            (None, None) => NormalState::Pass,
+        }
+    }
+}
+
 enum NailedOtherState {
     Dropped,
     Spicy {
@@ -70,47 +96,37 @@ enum NailedOtherState {
     Finished,
 }
 
-impl<T> NailedResponseFuture<T> {
-    #[inline]
-    pub fn normal(prune: Option<Boxed<()>>, delay: Option<Pin<Box<Sleep>>>, inner: T) -> Self {
-        let fut = match (prune, delay) {
-            (Some(prune), delay) => NailedState::Normal {
-                state: NailedNormalFuture {
-                    state: NormalState::Prune { prune, delay },
-                    inner,
-                },
-            },
-            (None, Some(delay)) => NailedState::Normal {
-                state: NailedNormalFuture {
-                    state: NormalState::Delay { delay },
-                    inner,
-                },
-            },
-            (None, None) => NailedState::Normal {
-                state: NailedNormalFuture {
-                    state: NormalState::Pass,
-                    inner,
-                },
-            },
-        };
+#[inline]
+#[cfg_attr(
+    feature = "detailed_traces",
+    tracing::instrument(name = "prune_old_peers", level = "trace", skip_all)
+)]
+fn prune() -> Boxed<()> {
+    boxed_future_within(async move || {
+        tracing::trace!("PRUNING STARTED");
 
-        Self { state: fut }
-    }
+        PEERS
+            .retain_async(|_, v| v.last_seen.elapsed() < crate::PEER_TIMEOUT)
+            .await
+    })
+}
 
+impl<S, T> NailedResponseFuture<S, T> {
     #[inline]
-    pub fn dropped() -> Self {
+    pub fn rate_peer(
+        peer: IdentifiedPeer,
+        spicy_payloads: Option<Arc<SpicyPayloads>>,
+        mode: LimitModes,
+        req: Request,
+        inner: S,
+    ) -> Self {
         Self {
-            state: NailedState::Other {
-                state: NailedOtherState::Dropped,
-            },
-        }
-    }
-
-    #[inline]
-    pub fn spicy(payload: Bytes, kind: SpicyPayloadKind) -> Self {
-        Self {
-            state: NailedState::Other {
-                state: NailedOtherState::Spicy { payload, kind },
+            state: NailedState::RatePeer {
+                req: Some(req),
+                mode,
+                spicy_payloads,
+                entry: boxed_future_within(|| PEERS.entry_async(peer)),
+                inner,
             },
         }
     }
@@ -125,17 +141,91 @@ impl<T> NailedResponseFuture<T> {
     }
 }
 
-impl<E, F> Future for NailedResponseFuture<F>
+impl<E, F, S> Future for NailedResponseFuture<S, F>
 where
     F: Future<Output = Result<Response<Body>, E>>,
+    S: tower::Service<Request, Response = Response<Body>, Future = F> + Send + 'static,
+    S::Future: Send + 'static,
 {
     type Output = Result<Response<Body>, E>;
 
     #[inline]
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        match self.project().state.project() {
-            NailedStateProj::Normal { state } => state.poll(cx),
-            NailedStateProj::Other { state } => Poll::Ready(Ok(state.build_response())),
+        let mut state = self.project().state;
+
+        loop {
+            match state.as_mut().project() {
+                NailedStateProj::RatePeer {
+                    req,
+                    spicy_payloads,
+                    mode,
+                    entry,
+                    inner,
+                } => {
+                    let entry = ready!(entry.poll(cx));
+                    let req = req.take().unwrap(); // If this panics, it is because the future was polled twice in the wrong state.
+                    let peer = entry
+                        .and_modify(|p| {
+                            p.count += 1;
+                            p.last_seen = Instant::now();
+                            p.state = mode.limit(&p.count);
+                        })
+                        .or_insert_with_key(|proxied| {
+                            tracing::info!("remote.peer" = %proxied, "New remote peer");
+                            PeerRecord {
+                                count: 1,
+                                state: mode.limit(&1),
+                                last_seen: Instant::now(),
+                                supports_spicy: SpicyPayloadKind::accepts_encoding(req.headers()),
+                            }
+                        });
+
+                    let delay = match peer.state {
+                        PeerState::Ready => None,
+                        PeerState::Delay(delay) => Some(boxed_future_within(|| sleep(delay))),
+                        PeerState::SpicyDrop => {
+                            let new_state = spicy_payloads
+                                .as_deref()
+                                .zip(peer.supports_spicy)
+                                .and_then(|(payloads, kind)| {
+                                    payloads.get(&kind).map(|payload| (payload.clone(), kind))
+                                })
+                                .map_or_else(
+                                    || NailedState::Other {
+                                        state: NailedOtherState::Dropped,
+                                    },
+                                    |(payload, kind)| NailedState::Other {
+                                        state: NailedOtherState::Spicy { payload, kind },
+                                    },
+                                );
+
+                            state.set(new_state);
+
+                            continue;
+                        }
+                        _ => {
+                            state.set(NailedState::Other {
+                                state: NailedOtherState::Dropped,
+                            });
+
+                            continue;
+                        }
+                    };
+
+                    let prune = PRUNING_SCHEDULER.schedule(prune);
+
+                    let inner = inner.call(req);
+
+                    state.set(NailedState::Normal {
+                        state: NailedNormalFuture {
+                            state: NormalState::new(prune, delay),
+                            inner,
+                        },
+                    });
+                }
+                NailedStateProj::Normal { state } => return state.poll(cx),
+                NailedStateProj::Other { state } => return Poll::Ready(Ok(state.build_response())),
+            }
         }
     }
 }

--- a/crates/nailrater/src/lib.rs
+++ b/crates/nailrater/src/lib.rs
@@ -1,5 +1,6 @@
 mod futures;
 mod modes;
+mod scheduler;
 
 use std::{
     sync::{Arc, LazyLock},
@@ -8,53 +9,16 @@ use std::{
 
 use axum::{body::Body, extract::Request, response::Response};
 use futures::NailedResponseFuture;
-use futures_lite::future::Boxed;
 
-use hyper::HeaderMap;
 use modes::LimitModes;
-use nailbox::boxed_future_within;
 use nailconfig::RateLimitingConfig;
 use nailip::IdentifiedPeer;
 use nailspicy::{SpicyPayloadKind, SpicyPayloads};
-use parking_lot::Mutex;
 use rapidhash::quality::RandomState;
 use scc::HashMap;
-use tokio::time::sleep;
 use tracing_futures::{Instrument, Instrumented};
 
 const PEER_TIMEOUT: Duration = Duration::from_secs(60 * 2);
-
-struct Scheduler {
-    value: Mutex<Option<Instant>>,
-}
-
-impl Scheduler {
-    const fn new() -> Self {
-        Self {
-            value: Mutex::new(None),
-        }
-    }
-
-    #[inline]
-    fn schedule<F, T>(&self, task: F) -> Option<T>
-    where
-        F: Fn() -> T,
-    {
-        let mut inner = self.value.lock();
-        let elapsed = inner.get_or_insert_with(Instant::now).elapsed();
-
-        if elapsed >= PEER_TIMEOUT {
-            inner.take();
-            drop(inner);
-
-            Some(task())
-        } else {
-            None
-        }
-    }
-}
-
-static PRUNING_SCHEDULER: Scheduler = Scheduler::new();
 
 static PEERS: LazyLock<HashMap<IdentifiedPeer, PeerRecord, RandomState>> =
     LazyLock::new(Default::default);
@@ -122,61 +86,16 @@ impl<S> NailRater<S> {
             inner,
         }
     }
-
-    #[inline]
-    #[cfg_attr(
-        feature = "detailed_traces",
-        tracing::instrument(level = "trace", skip_all)
-    )]
-    fn track_visiting_peer(
-        &self,
-        proxied: &IdentifiedPeer,
-        headers: &HeaderMap,
-    ) -> (PeerState, Option<SpicyPayloadKind>) {
-        let peer = PEERS
-            .entry_sync(proxied.clone())
-            .and_modify(|p| {
-                p.count += 1;
-                p.last_seen = Instant::now();
-                p.state = self.mode.limit(&p.count);
-            })
-            .or_insert_with(|| {
-                tracing::info!("remote.peer" = %proxied, "New remote peer");
-                PeerRecord {
-                    count: 1,
-                    state: self.mode.limit(&1),
-                    last_seen: Instant::now(),
-                    supports_spicy: SpicyPayloadKind::accepts_encoding(headers),
-                }
-            });
-
-        (peer.state, peer.supports_spicy)
-    }
-
-    #[inline]
-    #[cfg_attr(
-        feature = "detailed_traces",
-        tracing::instrument(name = "prune_old_peers", level = "trace", skip_all)
-    )]
-    fn prune() -> Boxed<()> {
-        boxed_future_within(async move || {
-            tracing::trace!("PRUNING STARTED");
-
-            PEERS
-                .retain_async(|_, v| v.last_seen.elapsed() < crate::PEER_TIMEOUT)
-                .await
-        })
-    }
 }
 
-impl<S, ReqBody> tower::Service<Request<ReqBody>> for NailRater<S>
+impl<S> tower::Service<Request> for NailRater<S>
 where
-    S: tower::Service<Request<ReqBody>, Response = Response<Body>> + Send + 'static,
+    S: tower::Service<Request, Response = Response<Body>> + Clone + Send + 'static,
     S::Future: Send + 'static,
 {
     type Response = S::Response;
     type Error = S::Error;
-    type Future = Instrumented<NailedResponseFuture<S::Future>>;
+    type Future = Instrumented<NailedResponseFuture<S, S::Future>>;
 
     #[inline]
     fn poll_ready(
@@ -187,36 +106,15 @@ where
     }
 
     #[tracing::instrument(name = "rate_limiter", skip_all)]
-    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
-        let Some(proxied) = req.extensions().get::<IdentifiedPeer>() else {
+    fn call(&mut self, req: Request) -> Self::Future {
+        let Some(proxied) = req.extensions().get::<IdentifiedPeer>().cloned() else {
             return NailedResponseFuture::error().in_current_span();
         };
 
-        let (peer_state, supports_spicy) = self.track_visiting_peer(proxied, req.headers());
+        let cloned = self.inner.clone();
+        let ready_inner = core::mem::replace(&mut self.inner, cloned);
 
-        let delay = match peer_state {
-            PeerState::Ready => None,
-            PeerState::Delay(delay) => Some(boxed_future_within(|| sleep(delay))),
-            PeerState::SpicyDrop => {
-                return self
-                    .spicy_payload
-                    .as_deref()
-                    .zip(supports_spicy)
-                    .and_then(|(payloads, kind)| {
-                        payloads.get(&kind).map(|payload| (payload.clone(), kind))
-                    })
-                    .map_or_else(NailedResponseFuture::dropped, |(payload, kind)| {
-                        NailedResponseFuture::spicy(payload, kind)
-                    })
-                    .in_current_span();
-            }
-            _ => return NailedResponseFuture::dropped().in_current_span(),
-        };
-
-        let prune = PRUNING_SCHEDULER.schedule(Self::prune);
-
-        let inner = self.inner.call(req);
-
-        NailedResponseFuture::normal(prune, delay, inner).in_current_span()
+        NailedResponseFuture::rate_peer(proxied, self.spicy_payload.clone(), self.mode, req, ready_inner)
+            .in_current_span()
     }
 }

--- a/crates/nailrater/src/lib.rs
+++ b/crates/nailrater/src/lib.rs
@@ -107,14 +107,19 @@ where
 
     #[tracing::instrument(name = "rate_limiter", skip_all)]
     fn call(&mut self, req: Request) -> Self::Future {
-        let Some(proxied) = req.extensions().get::<IdentifiedPeer>().cloned() else {
+        let Some(proxied) = req.extensions().get::<IdentifiedPeer>() else {
             return NailedResponseFuture::error().in_current_span();
         };
 
         let cloned = self.inner.clone();
         let ready_inner = core::mem::replace(&mut self.inner, cloned);
 
-        NailedResponseFuture::rate_peer(proxied, self.spicy_payload.clone(), self.mode, req, ready_inner)
-            .in_current_span()
+        NailedResponseFuture::rate_peer(
+            proxied.clone(),
+            self.spicy_payload.clone(),
+            self.mode.clone(),
+            req,
+            ready_inner,
+        ).instrument(tracing::info_span!("rate_peer"))
     }
 }

--- a/crates/nailrater/src/modes.rs
+++ b/crates/nailrater/src/modes.rs
@@ -4,7 +4,7 @@ use nailconfig::{DropBehavior, RateLimitingConfig};
 
 use crate::PeerState;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LimitModes {
     None,
     Soft {

--- a/crates/nailrater/src/modes.rs
+++ b/crates/nailrater/src/modes.rs
@@ -4,7 +4,7 @@ use nailconfig::{DropBehavior, RateLimitingConfig};
 
 use crate::PeerState;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LimitModes {
     None,
     Soft {

--- a/crates/nailrater/src/scheduler.rs
+++ b/crates/nailrater/src/scheduler.rs
@@ -1,0 +1,37 @@
+use std::time::Instant;
+
+use parking_lot::Mutex;
+
+use crate::PEER_TIMEOUT;
+
+pub(crate) struct Scheduler {
+    value: Mutex<Option<Instant>>,
+}
+
+impl Scheduler {
+    const fn new() -> Self {
+        Self {
+            value: Mutex::new(None),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn schedule<F, T>(&self, task: F) -> Option<T>
+    where
+        F: Fn() -> T,
+    {
+        let mut inner = self.value.lock();
+        let elapsed = inner.get_or_insert_with(Instant::now).elapsed();
+
+        if elapsed >= PEER_TIMEOUT {
+            inner.take();
+            drop(inner);
+
+            Some(task())
+        } else {
+            None
+        }
+    }
+}
+
+pub(crate) static PRUNING_SCHEDULER: Scheduler = Scheduler::new();

--- a/crates/nailtrace/src/lib.rs
+++ b/crates/nailtrace/src/lib.rs
@@ -74,12 +74,15 @@ pub async fn trace_connection_layer(
 
     let root_name = format!("{http_method} {path}");
 
+    let mut peer = identified.peer().split(":");
+
     let span = info_span!(
         "HTTP request",
         http.request.method = %http_method,
         http.route = path, // to set by router of "webframework" after
         network.protocol.version = %http_flavor(req.version()),
-        client.address = identified.peer(),
+        client.address = Empty,
+        client.port = Empty,
         user_agent.original = headers
             .get(USER_AGENT)
             .and_then(header_value_to_str)
@@ -97,6 +100,14 @@ pub async fn trace_connection_layer(
         http.request.header.request_id = Empty, // to set
         error.type = Empty,
     );
+
+    if let Some(address) = peer.next() {
+        span.record("client.address", address);
+    }
+
+    if let Some(port) = peer.next() {
+        span.record("client.port", port);
+    }
 
     if let Some(request_id) = header_value_to_str(&request_id) {
         span.record("http.request.header.request_id", request_id);


### PR DESCRIPTION
Switches the previous synchronous access of the rate limiter HashMap to use the asynchronous entry API, removing a potential deadlock source. This means moving the rate limit handling into the response future and making the poll implementation there even more complicated. But in terms of performance, it is showing no regressions.